### PR TITLE
Feat/jpa entities for quiz management

### DIFF
--- a/src/main/java/uk/gegc/quizmaker/model/quizManagement/Category.java
+++ b/src/main/java/uk/gegc/quizmaker/model/quizManagement/Category.java
@@ -1,13 +1,13 @@
 package uk.gegc.quizmaker.model.quizManagement;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -18,7 +18,17 @@ import lombok.Setter;
 public class Category {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "category_id")
-    private Long id;
+    private UUID id;
+
+    @Size(min = 3, max = 100, message = "Category name length must be between 3 and 100 characters")
+    @Column(name = "category_name", nullable = false)
+    private String categoryName;
+
+    @Size(max = 1000, message = "Category description length must be between less than 1000 characters")
+    @Column(name = "category_description")
+    private String categoryDescription;
+
 
 }

--- a/src/main/java/uk/gegc/quizmaker/model/quizManagement/Category.java
+++ b/src/main/java/uk/gegc/quizmaker/model/quizManagement/Category.java
@@ -1,0 +1,24 @@
+package uk.gegc.quizmaker.model.quizManagement;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name="categories")
+public class Category {
+
+    @Id
+    @Column(name = "category_id")
+    private Long id;
+
+}

--- a/src/main/java/uk/gegc/quizmaker/model/quizManagement/Difficulty.java
+++ b/src/main/java/uk/gegc/quizmaker/model/quizManagement/Difficulty.java
@@ -1,0 +1,5 @@
+package uk.gegc.quizmaker.model.quizManagement;
+
+public enum Difficulty {
+    HARD, MEDIUM, EASY
+}

--- a/src/main/java/uk/gegc/quizmaker/model/quizManagement/Question.java
+++ b/src/main/java/uk/gegc/quizmaker/model/quizManagement/Question.java
@@ -1,0 +1,103 @@
+package uk.gegc.quizmaker.model.quizManagement;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "questions")
+public class Question {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToMany(
+            fetch = FetchType.LAZY,
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE}
+    )
+    @JoinTable(
+            name = "quiz_questions",
+            joinColumns = @JoinColumn(name = "question_id", nullable = false),
+            inverseJoinColumns = @JoinColumn(name = "quiz_id", nullable = false)
+    )
+    @NotNull
+    private List<Quiz> quizId = new ArrayList<>();
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 50)
+    QuestionType type;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "difficulty", nullable = false, length = 20)
+    private Difficulty difficulty;
+
+    @NotBlank
+    @Size(max = 1000, message = "Question text length must be less than 1000 characters")
+    @Column(name = "question", nullable = false, length = 1000)
+    private String questionText;
+
+    @NotNull
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "content", columnDefinition = "json", nullable = false)
+    private String content;
+
+    @Size(max = 500, message = "Hint length must be less than 500 characters")
+    @Column(name = "hint", length = 500)
+    private String hint;
+
+    @Size(max = 2000, message = "Explanation must be less than 2000 characters")
+    @Column(name = "explanation", length = 2000)
+    private String explanation;
+
+    @Size(max = 2048, message = "URL length is limited by 2048 characters")
+    @Column(name = "attachment_url", length = 2048)
+    private String attachmentUrl;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "boolean default false")
+    private Boolean isDeleted;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @ManyToMany(
+            fetch = FetchType.LAZY,
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE}
+    )
+    @JoinTable(
+            name = "question_tags",
+            joinColumns = @JoinColumn(name = "question_id", nullable = false),
+            inverseJoinColumns = @JoinColumn(name = "tag_id", nullable = false)
+    )
+    private List<Tag> tags = new ArrayList<>();
+
+}

--- a/src/main/java/uk/gegc/quizmaker/model/quizManagement/QuestionType.java
+++ b/src/main/java/uk/gegc/quizmaker/model/quizManagement/QuestionType.java
@@ -1,0 +1,5 @@
+package uk.gegc.quizmaker.model.quizManagement;
+
+public enum QuestionType {
+    MCQ_SINGLE, MCQ_MULTI, OPEN, FILL_GAP, COMPLIANCE, TRUE_FALSE, ORDERING, HOTSPOT
+}

--- a/src/main/java/uk/gegc/quizmaker/model/quizManagement/Quiz.java
+++ b/src/main/java/uk/gegc/quizmaker/model/quizManagement/Quiz.java
@@ -40,7 +40,6 @@ public class Quiz {
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
-    @NotBlank
     @Size(min = 3, max = 100, message = "Title length must be between 3 and 100 characters")
     @Column(name = "title", nullable = false, length = 100)
     private String title;
@@ -63,7 +62,7 @@ public class Quiz {
     @Min(value = 1, message = "Estimated time can't be less than 1 minute")
     @Max(value = 180, message = "Estimated time can't be more than 180 minutes")
     @Column(name = "estimated_time_min", nullable = false)
-    private Integer est_time;
+    private Integer estimatedTime;
 
     @NotNull
     @Column(name = "is_repetition_enabled", nullable = false)

--- a/src/main/java/uk/gegc/quizmaker/model/quizManagement/Quiz.java
+++ b/src/main/java/uk/gegc/quizmaker/model/quizManagement/Quiz.java
@@ -13,6 +13,9 @@ import org.hibernate.annotations.UpdateTimestamp;
 import uk.gegc.quizmaker.model.userManagment.User;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -25,9 +28,9 @@ import java.time.LocalDateTime;
 public class Quiz {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name="quiz_id")
-    private Long id;
+    private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "creator_id", nullable = false, updatable = false)
@@ -88,6 +91,17 @@ public class Quiz {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    @ManyToMany(
+            fetch = FetchType.LAZY,
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE}
+    )
+    @JoinTable(
+            name = "quiz_tags",
+            joinColumns = @JoinColumn(name = "quiz_id", nullable = false),
+            inverseJoinColumns = @JoinColumn(name = "tag_id", nullable = false)
+    )
+    private List<Tag> tags = new ArrayList<>();
 
     @PreRemove
     private void onSoftDelete() {

--- a/src/main/java/uk/gegc/quizmaker/model/quizManagement/Quiz.java
+++ b/src/main/java/uk/gegc/quizmaker/model/quizManagement/Quiz.java
@@ -1,0 +1,98 @@
+package uk.gegc.quizmaker.model.quizManagement;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.UpdateTimestamp;
+import uk.gegc.quizmaker.model.userManagment.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name="quizzes", uniqueConstraints = @UniqueConstraint(columnNames = {"creator_id", "title"}))
+@SQLDelete(sql = "UPDATE quizzes SET is_deleted = true, deleted_at = CURRENT_TIMESTAMP WHERE quiz_id = ?")
+@SQLRestriction("is_deleted = false")
+public class Quiz {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="quiz_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "creator_id", nullable = false, updatable = false)
+    private User creator;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @NotBlank
+    @Size(min = 3, max = 100, message = "Title length must be between 3 and 100 characters")
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Size(max = 1000, message = "Description must be at most 1000 characters long")
+    @Column(name = "description")
+    private String description;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "visibility", nullable = false, length = 20)
+    private Visibility visibility;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "difficulty", nullable = false, length = 20)
+    private Difficulty difficulty;
+
+    @NotNull
+    @Min(value = 1, message = "Estimated time can't be less than 1 minute")
+    @Max(value = 180, message = "Estimated time can't be more than 180 minutes")
+    @Column(name = "estimated_time_min", nullable = false)
+    private Integer est_time;
+
+    @NotNull
+    @Column(name = "is_repetition_enabled", nullable = false)
+    private Boolean isRepetitionEnabled;
+
+    @NotNull
+    @Column(name = "is_timer_enabled", nullable = false)
+    private Boolean timerEnabled;
+
+    @Min(value = 1, message = "Timer duration must be at least 1 minute")
+    @Max(value = 180, message = "Timer duration must be at most 180 minutes")
+    @Column(name = "timer_duration_min")
+    private Integer timerDuration;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "is_deleted")
+    private Boolean isDeleted;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PreRemove
+    private void onSoftDelete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/uk/gegc/quizmaker/model/quizManagement/Tag.java
+++ b/src/main/java/uk/gegc/quizmaker/model/quizManagement/Tag.java
@@ -1,0 +1,33 @@
+package uk.gegc.quizmaker.model.quizManagement;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "tags")
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "tag_id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Size(min = 3, max = 50, message = "Tag length must be between 3 and 50 characters")
+    @Column(name = "tag_name", length = 50, nullable = false, unique = true)
+    private String tagName;
+
+    @Size(min=3, max = 500, message = "Tag description length must be between 3 and 500 characters")
+    @Column(name = "tag_description", length = 500)
+    private String tagDescription;
+
+}

--- a/src/main/java/uk/gegc/quizmaker/model/quizManagement/Visibility.java
+++ b/src/main/java/uk/gegc/quizmaker/model/quizManagement/Visibility.java
@@ -1,0 +1,5 @@
+package uk.gegc.quizmaker.model.quizManagement;
+
+public enum Visibility {
+    PUBLIC, PRIVATE
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,4 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 # JPA / Hibernate
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true

--- a/src/test/java/uk/gegc/quizmaker/model/QuestionModelFieldsValidationTest.java
+++ b/src/test/java/uk/gegc/quizmaker/model/QuestionModelFieldsValidationTest.java
@@ -1,0 +1,65 @@
+package uk.gegc.quizmaker.model;
+
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import uk.gegc.quizmaker.model.quizManagement.Question;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+public class QuestionModelFieldsValidationTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUpValidator(){
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    public void questionTextTooLong_thenValidationFails(){
+        Question question = new Question();
+        question.setQuestionText("hi".repeat(501));
+        Set<ConstraintViolation<Question>> violations = validator.validateProperty(question, "questionText");
+
+        assertEquals(1, violations.size());
+        assertEquals("Question text length must be less than 1000 characters", violations.iterator().next().getMessage());
+    }
+
+    @Test
+    public void hintTooLong_thenValidationFails(){
+        Question question = new Question();
+        question.setHint("hi".repeat(251));
+        Set<ConstraintViolation<Question>> violations = validator.validateProperty(question, "hint");
+
+        assertEquals(1, violations.size());
+        assertEquals("Hint length must be less than 500 characters", violations.iterator().next().getMessage());
+    }
+
+    @Test
+    public void explanationTooLong_thenValidationFails(){
+        Question question = new Question();
+        question.setExplanation("hi".repeat(1001));
+        Set<ConstraintViolation<Question>> violations = validator.validateProperty(question, "explanation");
+
+        assertEquals(1, violations.size());
+        assertEquals("Explanation must be less than 2000 characters", violations.iterator().next().getMessage());
+    }
+
+    @Test
+    public void attachmentUrlTooLong_thenValidationFails(){
+        Question question = new Question();
+        question.setAttachmentUrl("hi".repeat(1025));
+        Set<ConstraintViolation<Question>> violations = validator.validateProperty(question, "attachmentUrl");
+
+        assertEquals(1, violations.size());
+        assertEquals("URL length is limited by 2048 characters", violations.iterator().next().getMessage());
+    }
+}

--- a/src/test/java/uk/gegc/quizmaker/model/QuizModelFieldValidationTest.java
+++ b/src/test/java/uk/gegc/quizmaker/model/QuizModelFieldValidationTest.java
@@ -1,0 +1,100 @@
+package uk.gegc.quizmaker.model;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import uk.gegc.quizmaker.model.quizManagement.Quiz;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class QuizModelFieldValidationTest {
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUpValidator(){
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    void whenTitleTooShort_thenValidationFails(){
+        Quiz quiz = new Quiz();
+        quiz.setTitle("Hi");
+        Set<ConstraintViolation<Quiz>> violations = validator.validateProperty(quiz, "title");
+
+        assertEquals(1, violations.size(), "Expected one violation on title");
+        ConstraintViolation<Quiz> violation = violations.iterator().next();
+        assertEquals("Title length must be between 3 and 100 characters", violation.getMessage());
+    }
+
+    @Test
+    void whenTitleTooLong_thenValidationFails(){
+        Quiz quiz = new Quiz();
+        quiz.setTitle("hi".repeat(52));
+        Set<ConstraintViolation<Quiz>> violations = validator.validateProperty(quiz, "title");
+
+        assertEquals(1, violations.size(), "Expected one violation on title");
+        ConstraintViolation<Quiz> violation = violations.iterator().next();
+        assertEquals("Title length must be between 3 and 100 characters", violation.getMessage());
+    }
+
+    @Test
+    void whenDescriptionTooLong_thenValidationFails(){
+        Quiz quiz = new Quiz();
+        quiz.setDescription("hi".repeat(501));
+        Set<ConstraintViolation<Quiz>> violations = validator.validateProperty(quiz, "description");
+
+        assertEquals(1, violations.size(), "Expected 1 violation on description");
+        ConstraintViolation<Quiz> violation = violations.iterator().next();
+        assertEquals("Description must be at most 1000 characters long", violation.getMessage());
+    }
+
+    @Test
+    void whenEstimatedTimeTooSmall_thenValidationFails(){
+        Quiz quiz = new Quiz();
+        quiz.setEstimatedTime(0);
+        Set<ConstraintViolation<Quiz>> violations = validator.validateProperty(quiz, "estimatedTime");
+
+        assertEquals(1, violations.size());
+        ConstraintViolation<Quiz> violation = violations.iterator().next();
+        assertEquals("Estimated time can't be less than 1 minute", violation.getMessage());
+    }
+
+    @Test
+    void whenEstimatedTimeTooBig_thenValidationFails(){
+        Quiz quiz = new Quiz();
+        quiz.setEstimatedTime(181);
+        Set<ConstraintViolation<Quiz>> violations = validator.validateProperty(quiz, "estimatedTime");
+
+
+        assertEquals(1, violations.size());
+        ConstraintViolation<Quiz> violation = violations.iterator().next();
+        assertEquals("Estimated time can't be more than 180 minutes", violation.getMessage());
+    }
+
+    @Test
+    void whenTimerDurationTooSmall_thenValidationFails(){
+        Quiz quiz = new Quiz();
+        quiz.setTimerDuration(0);
+        Set<ConstraintViolation<Quiz>> violations = validator.validateProperty(quiz,"timerDuration");
+
+        assertEquals(1, violations.size());
+        assertEquals("Timer duration must be at least 1 minute", violations.iterator().next().getMessage());
+    }
+
+    @Test
+    void whenTimerDurationTooBig_thenValidationFails(){
+        Quiz quiz = new Quiz();
+        quiz.setTimerDuration(181);
+        Set<ConstraintViolation<Quiz>> violations = validator.validateProperty(quiz,"timerDuration");
+
+        assertEquals(1, violations.size());
+        assertEquals("Timer duration must be at most 180 minutes", violations.iterator().next().getMessage());
+    }
+}


### PR DESCRIPTION
## Overview

This PR introduces the core JPA model for Quiz-Management and adds unit tests to verify bean-validation constraints on the Quiz and Question entities.

---

### feat(quiz-management): define JPA entities for Quiz, Question, Category & Tag
- Use `UUID` primary keys for all entities  
- Model **Quiz↔Question**, **Quiz↔Tag**, **Question↔Tag** via bidirectional `@ManyToMany` + join tables  
- Persist `Question.content` as JSON with `@JdbcTypeCode(SqlTypes.JSON)`  
- Apply Bean-Validation (`@NotNull`, `@NotBlank`, `@Size`, `@Min`/`@Max`)  
- Soft-delete support on Quiz (`@SQLDelete`, `@SQLRestriction`, `isDeleted`, `deletedAt`)  
- Auditing fields (`createdAt`/`updatedAt`) via `@CreationTimestamp`/`@UpdateTimestamp`  
- Add `QuestionType` & `Difficulty` enums  
- Enhance Category & Tag with descriptive fields and uniqueness constraints  

### test(quiz-management): add validation tests for Quiz & Question models
- **QuestionModelFieldsValidationTest**: checks length constraints on `questionText`, `hint`, `explanation`, `attachmentUrl`  
- **QuizModelFieldValidationTest**: checks constraints on `title`, `description`, `estimatedTime`, `timerDuration`  

Closes #3  