### PR TITLE
@gegcuk feat(error): add global exception handling

### DIFF
--- a/src/main/java/uk/gegc/quizmaker/controller/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/advice/GlobalExceptionHandler.java
@@ -1,0 +1,105 @@
+package uk.gegc.quizmaker.controller.advice;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import uk.gegc.quizmaker.exception.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    public record ErrorResponse(LocalDateTime timestamp, int status, String error, List<String> details){}
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponse handleNotFound(ResourceNotFoundException exception){
+        return new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.NOT_FOUND.value(),
+                "Not found",
+                List.of(exception.getMessage())
+        );
+    }
+
+    @ExceptionHandler({ValidationException.class, UnsupportedQuestionTypeException.class, ApiError.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleBadRequest(RuntimeException exception){
+        return new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                "Bad request",
+                List.of(exception.getMessage())
+        );
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ErrorResponse handleUnauthorized(UnauthorizedException exception){
+        return new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.UNAUTHORIZED.value(),
+                "Unauthorized",
+                List.of(exception.getMessage())
+        );
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        List<String> fieldErrors = new ArrayList<>();
+        for (FieldError fe : ex.getBindingResult().getFieldErrors()) {
+            fieldErrors.add(fe.getField() + ": " + fe.getDefaultMessage());
+        }
+
+        ErrorResponse body = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                "Validation Failed",
+                fieldErrors
+        );
+        return new ResponseEntity<>(body, headers, status);
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorResponse handleAll(Exception ex) {
+        return new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "Internal Server Error",
+                List.of("An unexpected error occurred")
+        );
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/uk/gegc/quizmaker/exception/ApiError.java
+++ b/src/main/java/uk/gegc/quizmaker/exception/ApiError.java
@@ -1,0 +1,7 @@
+package uk.gegc.quizmaker.exception;
+
+public class ApiError extends RuntimeException {
+    public ApiError(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gegc/quizmaker/exception/ResourceNotFoundException.java
+++ b/src/main/java/uk/gegc/quizmaker/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package uk.gegc.quizmaker.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+  public ResourceNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/uk/gegc/quizmaker/exception/UnauthorizedException.java
+++ b/src/main/java/uk/gegc/quizmaker/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package uk.gegc.quizmaker.exception;
+
+public class UnauthorizedException extends RuntimeException {
+  public UnauthorizedException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/uk/gegc/quizmaker/exception/UnsupportedQuestionTypeException.java
+++ b/src/main/java/uk/gegc/quizmaker/exception/UnsupportedQuestionTypeException.java
@@ -1,0 +1,7 @@
+package uk.gegc.quizmaker.exception;
+
+public class UnsupportedQuestionTypeException extends RuntimeException {
+  public UnsupportedQuestionTypeException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/uk/gegc/quizmaker/exception/ValidationException.java
+++ b/src/main/java/uk/gegc/quizmaker/exception/ValidationException.java
@@ -1,0 +1,7 @@
+package uk.gegc.quizmaker.exception;
+
+public class ValidationException extends RuntimeException {
+  public ValidationException(String message) {
+    super(message);
+  }
+}


### PR DESCRIPTION
This PR introduces a centralized error-handling mechanism across the API, ensuring consistent JSON error responses and HTTP status codes for common failure scenarios. It also defines a set of custom exception types used by the service and controller layers.
**Changes**
•	GlobalExceptionHandler (@RestControllerAdvice)
•	Extends ResponseEntityExceptionHandler
•	Handles:
•	ResourceNotFoundException → 404 Not Found
•	ValidationException, UnsupportedQuestionTypeException, ApiError → 400 Bad Request
•	UnauthorizedException → 401 Unauthorized
•	MethodArgumentNotValidException (bean validation failures) → 400 Bad Request with field-level messages
•	Fallback Exception → 500 Internal Server Error
**Custom exception classes in uk.gegc.quizmaker.exception:**
•	ResourceNotFoundException
•	ValidationException
•	UnsupportedQuestionTypeException
•	UnauthorizedException
•	ApiError

Closes #41 