### PR TITLE
@gegcuk feat/generate swagger open api documentation 38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,13 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.8</version>
+        </dependency>
+
     </dependencies>
 
     <!-- Build configuration -->

--- a/src/main/java/uk/gegc/quizmaker/config/OpenApiConfig.java
+++ b/src/main/java/uk/gegc/quizmaker/config/OpenApiConfig.java
@@ -1,0 +1,29 @@
+package uk.gegc.quizmaker.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI quizMakerOpenApi(){
+        return new OpenAPI()
+                .info(new Info()
+                        .title("QuizMaker API")
+                        .version("v1"))
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+    }
+
+}

--- a/src/main/java/uk/gegc/quizmaker/config/SecurityConfig.java
+++ b/src/main/java/uk/gegc/quizmaker/config/SecurityConfig.java
@@ -46,6 +46,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/tags/**").permitAll()
                         .requestMatchers(HttpMethod.GET,"/api/v1/categories/**").permitAll()
                         .requestMatchers(HttpMethod.GET,"/api/v1/questions/**").permitAll()
+                        .requestMatchers(HttpMethod.GET,"/v3/api-docs/**").permitAll()
+                        .requestMatchers(HttpMethod.GET,"/swagger-ui/**").permitAll()
+                        .requestMatchers(HttpMethod.GET,"/api/v1/docs/**").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtTokenProvider),

--- a/src/main/java/uk/gegc/quizmaker/controller/AttemptController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/AttemptController.java
@@ -1,5 +1,14 @@
 package uk.gegc.quizmaker.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +27,7 @@ import uk.gegc.quizmaker.service.attempt.AttemptService;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
+@Tag(name = "Attempts", description = "Endpoints for managing quiz attempts")
 @RestController
 @RequestMapping("/api/v1/attempts")
 @RequiredArgsConstructor
@@ -27,10 +36,34 @@ public class AttemptController {
 
     private final AttemptService attemptService;
 
+    @Operation(
+            summary = "Start an attempt for a quiz",
+            description = "Creates a new attempt for the given quiz and returns its ID."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Attempt started successfully",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(
+                                    example = "{\"attemptId\":\"3fa85f64-5717-4562-b3fc-2c963f66afa6\"}"
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "Quiz not found")
+    })
     @PostMapping("/quizzes/{quizId}")
     public ResponseEntity<Map<String, UUID>> startAttempt(
+            @Parameter(description = "Quiz UUID to start an attempt for", required = true)
             @PathVariable UUID quizId,
+
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Optional request body specifying the attempt mode",
+                    required = false,
+                    content = @Content(
+                            schema = @Schema(implementation = StartAttemptRequest.class)
+                    )
+            )
             @RequestBody(required = false) @Valid StartAttemptRequest request,
+
             Authentication authentication
     ) {
         String username = authentication.getName();
@@ -42,12 +75,32 @@ public class AttemptController {
                 .body(Map.of("attemptId", dto.attemptId()));
     }
 
+    @Operation(
+            summary = "List attempts",
+            description = "Retrieves a paginated list of attempts for the authenticated user, optionally filtered by quizId or userId."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of attempts returned",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = AttemptDto.class)
+                    )
+            )
+    })
     @GetMapping
     public ResponseEntity<Page<AttemptDto>> listAttempts(
-            @RequestParam(name = "page", defaultValue = "0") @Min(0) int page,
-            @RequestParam(name = "size", defaultValue = "20") @Min(1) int size,
+            @Parameter(in = ParameterIn.QUERY, description = "Page number (0-based)", example = "0")
+            @Min(0) @RequestParam(name = "page", defaultValue = "0") int page,
+
+            @Parameter(in = ParameterIn.QUERY, description = "Page size", example = "20")
+            @Min(1) @RequestParam(name = "size", defaultValue = "20") int size,
+
+            @Parameter(in = ParameterIn.QUERY, description = "Filter by quiz UUID")
             @RequestParam(name = "quizId", required = false) UUID quizId,
+
+            @Parameter(in = ParameterIn.QUERY, description = "Filter by user UUID")
             @RequestParam(name = "userId", required = false) UUID userId,
+
             Authentication authentication
     ) {
         String username = authentication.getName();
@@ -60,9 +113,21 @@ public class AttemptController {
         return ResponseEntity.ok(result);
     }
 
+    @Operation(summary = "Get attempt details", description = "Retrieve detailed information for a specific attempt.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Attempt details returned",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = AttemptDetailsDto.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "Attempt not found")
+    })
     @GetMapping("/{attemptId}")
     public ResponseEntity<AttemptDetailsDto> getAttempt(
+            @Parameter(description = "UUID of the attempt to retrieve", required = true)
             @PathVariable UUID attemptId,
+
             Authentication authentication
     ) {
         String username = authentication.getName();
@@ -70,10 +135,29 @@ public class AttemptController {
         return ResponseEntity.ok(details);
     }
 
+    @Operation(summary = "Submit a single answer", description = "Submit an answer to a specific question within an attempt.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Answer submission result",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = AnswerSubmissionDto.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Validation error"),
+            @ApiResponse(responseCode = "404", description = "Attempt or question not found")
+    })
     @PostMapping("/{attemptId}/answers")
     public ResponseEntity<AnswerSubmissionDto> submitAnswer(
+            @Parameter(description = "UUID of the attempt", required = true)
             @PathVariable UUID attemptId,
+
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Answer submission payload",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = AnswerSubmissionRequest.class))
+            )
             @RequestBody @Valid AnswerSubmissionRequest request,
+
             Authentication authentication
     ) {
         String username = authentication.getName();
@@ -81,10 +165,30 @@ public class AttemptController {
         return ResponseEntity.ok(answer);
     }
 
+    @Operation(summary = "Submit batch of answers", description = "Submit multiple answers at once (only for ALL_AT_ONCE mode).")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Batch answers submitted",
+                    content = @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = AnswerSubmissionDto.class))
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Validation error"),
+            @ApiResponse(responseCode = "404", description = "Attempt not found"),
+            @ApiResponse(responseCode = "409", description = "Invalid attempt mode or duplicate answers")
+    })
     @PostMapping("/{attemptId}/answers/batch")
     public ResponseEntity<List<AnswerSubmissionDto>> submitBatch(
+            @Parameter(description = "UUID of the attempt", required = true)
             @PathVariable UUID attemptId,
+
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Batch answer submission payload",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = BatchAnswerSubmissionRequest.class))
+            )
             @RequestBody @Valid BatchAnswerSubmissionRequest request,
+
             Authentication authentication
     ) {
         String username = authentication.getName();
@@ -93,13 +197,27 @@ public class AttemptController {
         return ResponseEntity.ok(answers);
     }
 
+    @Operation(summary = "Complete an attempt", description = "Marks the attempt as completed and returns the results.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Attempt completed successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = AttemptResultDto.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "Attempt not found"),
+            @ApiResponse(responseCode = "409", description = "Attempt in invalid state")
+    })
     @PostMapping("/{attemptId}/complete")
     public ResponseEntity<AttemptResultDto> completeAttempt(
+            @Parameter(description = "UUID of the attempt", required = true)
             @PathVariable UUID attemptId,
+
             Authentication authentication
     ) {
         String username = authentication.getName();
         AttemptResultDto result = attemptService.completeAttempt(username, attemptId);
         return ResponseEntity.ok(result);
     }
+
 }

--- a/src/main/java/uk/gegc/quizmaker/controller/AuthController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/AuthController.java
@@ -1,5 +1,13 @@
 package uk.gegc.quizmaker.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -14,6 +22,7 @@ import uk.gegc.quizmaker.dto.auth.RegisterRequest;
 import uk.gegc.quizmaker.dto.user.UserDto;
 import uk.gegc.quizmaker.service.auth.AuthService;
 
+@Tag(name = "Authentication", description = "Endpoints for registering, logging in, refreshing tokens, logout, and fetching current user")
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -21,37 +30,104 @@ public class AuthController {
 
     private final AuthService authService;
 
+    @Operation(
+            summary = "Register a new user",
+            description = "Creates a new user account. Returns the created user's details."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "User successfully registered"),
+            @ApiResponse(responseCode = "400", description = "Validation errors"),
+            @ApiResponse(responseCode = "409", description = "Username or email already in use")
+    })
     @PostMapping("/register")
-    public ResponseEntity<UserDto> register(@Valid @RequestBody RegisterRequest request){
+    public ResponseEntity<UserDto> register(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Registration information",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = RegisterRequest.class))
+            )
+            @Valid @RequestBody RegisterRequest request
+    ) {
         UserDto createdUser = authService.register(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdUser);
     }
 
+    @Operation(
+            summary = "Log in",
+            description = "Authenticates a user and returns access and refresh JWT tokens."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Login successful"),
+            @ApiResponse(responseCode = "401", description = "Invalid credentials")
+    })
     @PostMapping("/login")
-    public ResponseEntity<JwtResponse> login(@Valid @RequestBody LoginRequest request){
+    public ResponseEntity<JwtResponse> login(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Username (or email) and password",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = LoginRequest.class))
+            )
+            @Valid @RequestBody LoginRequest request
+    ) {
         JwtResponse tokens = authService.login(request);
         return ResponseEntity.ok(tokens);
     }
 
+    @Operation(
+            summary = "Refresh tokens",
+            description = "Exchanges a valid refresh token for a new access token (and optionally a new refresh token)."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Tokens refreshed"),
+            @ApiResponse(responseCode = "401", description = "Invalid or expired refresh token")
+    })
     @PostMapping("/refresh")
-    public ResponseEntity<JwtResponse> refresh(@RequestBody RefreshRequest refreshRequest){
+    public ResponseEntity<JwtResponse> refresh(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Refresh token payload",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = RefreshRequest.class))
+            )
+            @RequestBody RefreshRequest refreshRequest
+    ) {
         return ResponseEntity.ok(authService.refresh(refreshRequest));
     }
 
+    @Operation(
+            summary = "Logout",
+            description = "Revokes the provided access token."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Logout successful"),
+            @ApiResponse(responseCode = "401", description = "Invalid or missing token")
+    })
     @PostMapping("/logout")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     public void logout(
+            @Parameter(
+                    description = "Bearer access token",
+                    in = ParameterIn.HEADER,
+                    name = HttpHeaders.AUTHORIZATION,
+                    required = true,
+                    schema = @Schema(type = "string", example = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+            )
             @RequestHeader(HttpHeaders.AUTHORIZATION) String header
-    ){
+    ) {
         String token = header.replaceFirst("^Bearer\\s+", "");
         authService.logout(token);
     }
 
+    @Operation(
+            summary = "Get current user",
+            description = "Returns details of the authenticated user."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Current user retrieved"),
+            @ApiResponse(responseCode = "401", description = "Not authenticated")
+    })
     @GetMapping("/me")
     public ResponseEntity<UserDto> me(
             Authentication authentication
-            ){
+    ) {
         return ResponseEntity.ok(authService.getCurrentUser(authentication));
     }
-
 }

--- a/src/main/java/uk/gegc/quizmaker/controller/CategoryController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/CategoryController.java
@@ -1,7 +1,16 @@
 package uk.gegc.quizmaker.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -20,6 +29,10 @@ import uk.gegc.quizmaker.service.category.CategoryService;
 import java.util.Map;
 import java.util.UUID;
 
+@Tag(
+        name = "Categories",
+        description = "Operations for managing quiz categories"
+)
 @RestController
 @RequestMapping("/api/v1/categories")
 @RequiredArgsConstructor
@@ -27,43 +40,119 @@ public class CategoryController {
 
     private final CategoryService categoryService;
 
+    @Operation(
+            summary = "List categories",
+            description = "Get a paginated list of categories, sorted by name ascending",
+            tags = { "Categories" }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of categories returned")
+    })
     @GetMapping
     public ResponseEntity<Page<CategoryDto>> getCategories(
+            @ParameterObject
             @PageableDefault(page = 0, size = 20)
             @SortDefault(sort = "name", direction = Sort.Direction.ASC)
             Pageable pageable
     ) {
-        Page<CategoryDto> categoryDtosPage = categoryService.getCategories(pageable);
-        return ResponseEntity.ok(categoryDtosPage);
+        return ResponseEntity.ok(categoryService.getCategories(pageable));
     }
 
+    @Operation(
+            summary = "Create a category",
+            description = "Create a new category. Requires ADMIN role.",
+            tags = { "Categories" }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Category created"),
+            @ApiResponse(responseCode = "400", description = "Validation error"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden")
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Category to create",
+            required = true,
+            content = @Content(schema = @Schema(implementation = CreateCategoryRequest.class))
+    )
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<Map<String, UUID>> createCategory(@RequestBody @Valid CreateCategoryRequest request, Authentication authentication) {
+    public ResponseEntity<Map<String, UUID>> createCategory(
+            Authentication authentication,
+            @RequestBody @Valid CreateCategoryRequest request
+    ) {
         UUID categoryId = categoryService.createCategory(authentication.getName(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("categoryId", categoryId));
     }
 
+    @Operation(
+            summary = "Get category by ID",
+            description = "Retrieve a category by its UUID",
+            tags = { "Categories" }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Category returned"),
+            @ApiResponse(responseCode = "404", description = "Category not found")
+    })
     @GetMapping("/{categoryId}")
-    public ResponseEntity<CategoryDto> getCategoryById(@PathVariable UUID categoryId) {
+    public ResponseEntity<CategoryDto> getCategoryById(
+            @Parameter(description = "UUID of the category", required = true)
+            @PathVariable UUID categoryId
+    ) {
         return ResponseEntity.ok(categoryService.getCategoryById(categoryId));
     }
 
+    @Operation(
+            summary = "Update a category",
+            description = "Update name and/or description of an existing category. Requires ADMIN role.",
+            tags = { "Categories" }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Category updated"),
+            @ApiResponse(responseCode = "400", description = "Validation error"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(responseCode = "404", description = "Category not found")
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Updated category data",
+            required = true,
+            content = @Content(schema = @Schema(implementation = UpdateCategoryRequest.class))
+    )
     @PatchMapping("/{categoryId}")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<CategoryDto> updateCategory(
+            @Parameter(description = "UUID of the category", required = true)
             @PathVariable UUID categoryId,
-            @RequestBody @Valid UpdateCategoryRequest request,
-            Authentication authentication
+            Authentication authentication,
+            @RequestBody @Valid UpdateCategoryRequest request
     ) {
-        return ResponseEntity.ok(categoryService.updateCategoryById(authentication.getName(), categoryId, request));
+        return ResponseEntity.ok(
+                categoryService.updateCategoryById(authentication.getName(), categoryId, request)
+        );
     }
 
+    @Operation(
+            summary = "Delete a category",
+            description = "Delete a category by its UUID. Requires ADMIN role.",
+            tags = { "Categories" }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Category deleted"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(responseCode = "404", description = "Category not found")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @DeleteMapping("/{categoryId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasRole('ADMIN')")
-    public void deleteCategory(@PathVariable UUID categoryId, Authentication authentication) {
+    public void deleteCategory(
+            @Parameter(description = "UUID of the category", required = true)
+            @PathVariable UUID categoryId,
+            Authentication authentication
+    ) {
         categoryService.deleteCategoryById(authentication.getName(), categoryId);
     }
-
 }

--- a/src/main/java/uk/gegc/quizmaker/controller/QuestionController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/QuestionController.java
@@ -1,5 +1,14 @@
 package uk.gegc.quizmaker.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -18,52 +27,147 @@ import uk.gegc.quizmaker.service.question.QuestionService;
 
 import java.util.Map;
 import java.util.UUID;
-
+@Tag(
+        name = "Questions",
+        description = "Operations for managing quiz questions"
+)
 @RestController
 @RequestMapping("/api/v1/questions")
 @RequiredArgsConstructor
 public class QuestionController {
+
     private final QuestionService questionService;
 
+    @Operation(
+            summary = "Create a question",
+            description = "Add a new question (ADMIN only)",
+            tags = { "Questions" }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Question created"),
+            @ApiResponse(responseCode = "400", description = "Validation error"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden")
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Question to create",
+            required = true,
+            content = @Content(schema = @Schema(implementation = CreateQuestionRequest.class))
+    )
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<Map<String, UUID>> createQuestion(@RequestBody @Valid CreateQuestionRequest request,
-                                                            Authentication authentication) {
+    public ResponseEntity<Map<String, UUID>> createQuestion(
+            Authentication authentication,
+            @RequestBody @Valid CreateQuestionRequest request
+    ) {
         UUID id = questionService.createQuestion(authentication.getName(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("questionId", id));
     }
 
+    @Operation(
+            summary = "List questions",
+            description = "Get a page of questions, optionally filtered by quizId",
+            tags = { "Questions" }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of questions returned")
+    })
     @GetMapping
     public ResponseEntity<Page<QuestionDto>> getQuestions(
+            @Parameter(
+                    in = ParameterIn.QUERY,
+                    description = "Filter by quiz UUID",
+                    required = false
+            )
             @RequestParam(required = false) UUID quizId,
-            @RequestParam(defaultValue = "0") int pageNumber,
-            @RequestParam(defaultValue = "20") int size) {
 
+            @Parameter(
+                    in = ParameterIn.QUERY,
+                    description = "Page number (0-based)",
+                    example = "0"
+            )
+            @RequestParam(defaultValue = "0") int pageNumber,
+
+            @Parameter(
+                    in = ParameterIn.QUERY,
+                    description = "Page size",
+                    example = "20"
+            )
+            @RequestParam(defaultValue = "20") int size
+    ) {
         Pageable page = PageRequest.of(pageNumber, size, Sort.by("createdAt").descending());
-        Page<QuestionDto> questionDtoPage = questionService.listQuestions(quizId, page);
-        return ResponseEntity.ok(questionDtoPage);
+        return ResponseEntity.ok(questionService.listQuestions(quizId, page));
     }
 
+    @Operation(
+            summary = "Get question by ID",
+            description = "Retrieve a single question by its UUID",
+            tags = { "Questions" }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Question returned"),
+            @ApiResponse(responseCode = "404", description = "Question not found")
+    })
     @GetMapping("/{id}")
-    public ResponseEntity<QuestionDto> getQuestion(@PathVariable UUID id) {
+    public ResponseEntity<QuestionDto> getQuestion(
+            @Parameter(description = "UUID of the question", required = true)
+            @PathVariable UUID id
+    ) {
         return ResponseEntity.ok(questionService.getQuestion(id));
     }
 
+    @Operation(
+            summary = "Update a question",
+            description = "Modify an existing question (ADMIN only)",
+            tags = { "Questions" }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Question updated"),
+            @ApiResponse(responseCode = "400", description = "Validation error"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(responseCode = "404", description = "Question not found")
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Updated question data",
+            required = true,
+            content = @Content(schema = @Schema(implementation = UpdateQuestionRequest.class))
+    )
     @PatchMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<QuestionDto> updateQuestion(
+            @Parameter(description = "UUID of the question", required = true)
             @PathVariable UUID id,
-            @RequestBody @Valid UpdateQuestionRequest request,
-            Authentication authentication
+            Authentication authentication,
+            @RequestBody @Valid UpdateQuestionRequest request
     ) {
-
-        return ResponseEntity.ok(questionService.updateQuestion(authentication.getName(), id, request));
+        return ResponseEntity.ok(
+                questionService.updateQuestion(authentication.getName(), id, request)
+        );
     }
 
+    @Operation(
+            summary = "Delete a question",
+            description = "Remove a question by its UUID (ADMIN only)",
+            tags = { "Questions" }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Question deleted"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(responseCode = "404", description = "Question not found")
+    })
+    @SecurityRequirement(name = "bearerAuth")
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasRole('ADMIN')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteQuestion(@PathVariable UUID id, Authentication authentication) {
+    @PreAuthorize("hasRole('ADMIN')")
+    public void deleteQuestion(
+            @Parameter(description = "UUID of the question", required = true)
+            @PathVariable UUID id,
+            Authentication authentication
+    ) {
         questionService.deleteQuestion(authentication.getName(), id);
     }
 }

--- a/src/main/java/uk/gegc/quizmaker/controller/QuizController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/QuizController.java
@@ -1,7 +1,13 @@
 package uk.gegc.quizmaker.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -11,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import uk.gegc.quizmaker.dto.quiz.CreateQuizRequest;
 import uk.gegc.quizmaker.dto.quiz.QuizDto;
@@ -23,14 +30,28 @@ import uk.gegc.quizmaker.service.quiz.QuizService;
 import java.util.Map;
 import java.util.UUID;
 
+
+@Tag(name = "Quizzes", description = "Operations for creating, reading, updating, deleting and associating quizzes.")
 @RestController
 @RequestMapping("/api/v1/quizzes")
 @RequiredArgsConstructor
+@Validated
 public class QuizController {
 
     private final QuizService quizService;
     private final AttemptService attemptService;
 
+    @Operation(
+            summary = "Create a new quiz",
+            description = "Requires ADMIN role. Returns the generated UUID of the created quiz."
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Payload for creating a new quiz",
+            required = true,
+            content = @Content(
+                    schema = @Schema(implementation = CreateQuizRequest.class)
+            )
+    )
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Map<String, UUID>> createQuiz(@RequestBody @Valid CreateQuizRequest request,
@@ -39,26 +60,52 @@ public class QuizController {
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("quizId", quizId));
     }
 
+    @Operation(
+            summary = "List quizzes with pagination and optional filters",
+            description = "Returns a page of quizzes; you can page/sort via `page`, `size`, `sort`, and filter via the fields of QuizSearchCriteria"
+    )
     @GetMapping
     public ResponseEntity<Page<QuizDto>> getQuizzes(
+            @ParameterObject
             @PageableDefault(page = 0, size = 20)
             @SortDefault(sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable,
-            @ModelAttribute QuizSearchCriteria quizSearchCriteria
-    ) {
 
-        Page<QuizDto> questionDtoPage = quizService.getQuizzes(pageable, quizSearchCriteria);
-        return ResponseEntity.ok((questionDtoPage));
+            @ParameterObject
+            @ModelAttribute
+            QuizSearchCriteria quizSearchCriteria
+    ) {
+        Page<QuizDto> quizPage = quizService.getQuizzes(pageable, quizSearchCriteria);
+        return ResponseEntity.ok(quizPage);
     }
 
+
+    @Operation(
+            summary = "Get a quiz by its ID",
+            description = "Returns full QuizDto; 404 if not found."
+    )
     @GetMapping("/{quizId}")
-    public ResponseEntity<QuizDto> getQuiz(@PathVariable UUID quizId) {
+    public ResponseEntity<QuizDto> getQuiz(
+            @Parameter(description = "UUID of the quiz to retrieve", required = true)
+            @PathVariable UUID quizId) {
         return ResponseEntity.ok(quizService.getQuizById(quizId));
     }
 
+    @Operation(
+            summary = "Update an existing quiz",
+            description = "ADMIN only. Only provided fields will be updated."
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Fields to update in the quiz",
+            required = true,
+            content = @Content(
+                    schema = @Schema(implementation = UpdateQuizRequest.class)
+            )
+    )
     @PatchMapping("/{quizId}")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<QuizDto> updateQuiz(
+            @Parameter(description = "UUID of the quiz to update", required = true)
             @PathVariable UUID quizId,
             @RequestBody @Valid UpdateQuizRequest request,
             Authentication authentication
@@ -68,71 +115,112 @@ public class QuizController {
         );
     }
 
+    @Operation(
+            summary = "Delete a quiz",
+            description = "ADMIN only. Permanently deletes the quiz."
+    )
     @DeleteMapping("/{quizId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasRole('ADMIN')")
-    public void deleteQuiz(@PathVariable UUID quizId,
+    public void deleteQuiz(
+            @Parameter(description = "UUID of the quiz to delete", required = true)
+            @PathVariable UUID quizId,
                            Authentication authentication) {
         quizService.deleteQuizById(authentication.getName(), quizId);
     }
 
+    @Operation(
+            summary = "Associate a question with a quiz",
+            description = "ADMIN only. Adds an existing question to the quiz."
+    )
     @PostMapping("/{quizId}/questions/{questionId}")
     @PreAuthorize("hasRole('ADMIN')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void addQuestion(
+            @Parameter(description = "UUID of the quiz", required = true)
             @PathVariable UUID quizId,
+            @Parameter(description = "UUID of the question", required = true)
             @PathVariable UUID questionId,
             Authentication authentication
     ) {
         quizService.addQuestionToQuiz(authentication.getName(), quizId, questionId);
     }
 
+    @Operation(
+            summary = "Remove a question from a quiz",
+            description = "ADMIN only."
+    )
     @DeleteMapping("/{quizId}/questions/{questionId}")
     @PreAuthorize("hasRole('ADMIN')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeQuestion(
+            @Parameter(description = "UUID of the quiz", required = true)
             @PathVariable UUID quizId,
+            @Parameter(description = "UUID of the question", required = true)
             @PathVariable UUID questionId,
             Authentication authentication
     ) {
         quizService.removeQuestionFromQuiz(authentication.getName(), quizId, questionId);
     }
 
+    @Operation(
+            summary = "Add a tag to a quiz",
+            description = "ADMIN only."
+    )
     @PostMapping("/{quizId}/tags/{tagId}")
     @PreAuthorize("hasRole('ADMIN')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void addTag(
+            @Parameter(description = "UUID of the quiz", required = true)
             @PathVariable UUID quizId,
+            @Parameter(description = "UUID of the tag", required = true)
             @PathVariable UUID tagId,
             Authentication authentication
     ) {
         quizService.addTagToQuiz(authentication.getName(), quizId, tagId);
     }
 
+    @Operation(
+            summary = "Remove a tag from a quiz",
+            description = "ADMIN only."
+    )
     @DeleteMapping("/{quizId}/tags/{tagId}")
     @PreAuthorize("hasRole('ADMIN')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeTag(
+            @Parameter(description = "UUID of the quiz", required = true)
             @PathVariable UUID quizId,
+            @Parameter(description = "UUID of the tag", required = true)
             @PathVariable UUID tagId,
             Authentication authentication
     ) {
         quizService.removeTagFromQuiz(authentication.getName(), quizId, tagId);
     }
 
+    @Operation(
+            summary = "Change a quiz’s category",
+            description = "ADMIN only."
+    )
     @PatchMapping("/{quizId}/category/{categoryId}")
     @PreAuthorize("hasRole('ADMIN')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void changeCategory(
+            @Parameter(description = "UUID of the quiz", required = true)
             @PathVariable UUID quizId,
+            @Parameter(description = "UUID of the new category", required = true)
             @PathVariable UUID categoryId,
             Authentication authentication
     ) {
         quizService.changeCategory(authentication.getName(), quizId, categoryId);
     }
 
+    @Operation(
+            summary = "Get aggregated quiz results summary",
+            description = "Returns counts, scores, pass rate and per-question stats."
+    )
     @GetMapping("/{quizId}/results")
     public ResponseEntity<QuizResultSummaryDto> getQuizResults(
+            @Parameter(description = "UUID of the quiz to summarize", required = true)
             @PathVariable UUID quizId
     ) {
         return ResponseEntity.ok(attemptService.getQuizResultSummary(quizId));

--- a/src/main/java/uk/gegc/quizmaker/controller/TagController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/TagController.java
@@ -1,8 +1,17 @@
 package uk.gegc.quizmaker.controller;
 
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -21,6 +30,7 @@ import uk.gegc.quizmaker.service.tag.TagService;
 import java.util.Map;
 import java.util.UUID;
 
+@Tag(name = "Tags", description = "Operations for managing tags")
 @RestController
 @RequestMapping("/api/v1/tags")
 @RequiredArgsConstructor
@@ -28,8 +38,16 @@ public class TagController {
 
     private final TagService tagService;
 
+    @Operation(
+            summary = "List tags with pagination",
+            description = "Returns a paged list of tags, sorted by name by default."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of TagDto")
+    })
     @GetMapping
     public ResponseEntity<Page<TagDto>> getTags(
+            @ParameterObject
             @PageableDefault(page = 0, size = 20)
             @SortDefault(sort = "name", direction = Sort.Direction.ASC)
             Pageable pageable
@@ -38,34 +56,93 @@ public class TagController {
         return ResponseEntity.ok(tagDtosPage);
     }
 
-    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(
+            summary = "Create a new tag",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "Tag created, returns its ID"),
+                    @ApiResponse(responseCode = "400", description = "Validation error"),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                    @ApiResponse(responseCode = "403", description = "Forbidden")
+            }
+    )
     @PostMapping
-    public ResponseEntity<Map<String, UUID>> createTag(@RequestBody @Valid CreateTagRequest request, Authentication authentication) {
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Map<String, UUID>> createTag(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Payload to create a new tag",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = CreateTagRequest.class))
+            )
+            @Valid @RequestBody CreateTagRequest request,
+            Authentication authentication
+    ) {
         UUID tagId = tagService.createTag(authentication.getName(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("tagId", tagId));
     }
 
+    @Operation(
+            summary = "Get a tag by ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "TagDto"),
+                    @ApiResponse(responseCode = "404", description = "Tag not found")
+            }
+    )
     @GetMapping("/{tagId}")
-    public ResponseEntity<TagDto> getTagById(@PathVariable UUID tagId) {
+    public ResponseEntity<TagDto> getTagById(
+            @Parameter(description = "UUID of the tag", required = true)
+            @PathVariable UUID tagId
+    ) {
         return ResponseEntity.ok(tagService.getTagById(tagId));
     }
 
-    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(
+            summary = "Update an existing tag",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Updated TagDto"),
+                    @ApiResponse(responseCode = "400", description = "Validation error"),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                    @ApiResponse(responseCode = "403", description = "Forbidden"),
+                    @ApiResponse(responseCode = "404", description = "Tag not found")
+            }
+    )
     @PatchMapping("/{tagId}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<TagDto> updateTag(
+            @Parameter(description = "UUID of the tag to update", required = true)
             @PathVariable UUID tagId,
-            @RequestBody @Valid UpdateTagRequest request,
+
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Fields to update in the tag",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = UpdateTagRequest.class))
+            )
+            @Valid @RequestBody UpdateTagRequest request,
+
             Authentication authentication
     ) {
         return ResponseEntity.ok(tagService.updateTagById(authentication.getName(), tagId, request));
     }
 
-    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(
+            summary = "Delete a tag",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Tag deleted"),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                    @ApiResponse(responseCode = "403", description = "Forbidden"),
+                    @ApiResponse(responseCode = "404", description = "Tag not found")
+            }
+    )
     @DeleteMapping("/{tagId}")
+    @PreAuthorize("hasRole('ADMIN')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteTag(@PathVariable UUID tagId, Authentication authentication) {
+    public void deleteTag(
+            @Parameter(description = "UUID of the tag to delete", required = true)
+            @PathVariable UUID tagId,
+            Authentication authentication
+    ) {
         tagService.deleteTagById(authentication.getName(), tagId);
     }
-
 }
-

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/AnswerSubmissionDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/AnswerSubmissionDto.java
@@ -1,16 +1,28 @@
 package uk.gegc.quizmaker.dto.attempt;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gegc.quizmaker.dto.question.QuestionDto;
 
 import java.time.Instant;
 import java.util.UUID;
 
+@Schema(name = "AnswerSubmissionDto", description = "Result of submitting an answer to a question")
 public record AnswerSubmissionDto(
+        @Schema(description = "UUID of the answer record", example = "4b3a2c1d-0f9e-8d7c-6b5a-4c3b2a1d0e9f")
         UUID answerId,
+
+        @Schema(description = "UUID of the question", example = "abcdef12-3456-7890-abcd-ef1234567890")
         UUID questionId,
+
+        @Schema(description = "Whether the submitted answer was correct", example = "true")
         Boolean isCorrect,
+
+        @Schema(description = "Score awarded for this answer", example = "1.0")
         Double score,
+
+        @Schema(description = "Timestamp when the answer was recorded", example = "2025-05-20T14:35:00Z")
         Instant answeredAt,
+
+        @Schema(description = "Next question in ONE_BY_ONE mode, if any")
         QuestionDto nextQuestion
-) {
-}
+) {}

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/AnswerSubmissionRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/AnswerSubmissionRequest.java
@@ -1,15 +1,29 @@
 package uk.gegc.quizmaker.dto.attempt;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
 
+@Schema(
+        name = "AnswerSubmissionRequest",
+        description = "Payload for submitting an answer to a specific question"
+)
 public record AnswerSubmissionRequest(
+        @Schema(
+                description = "UUID of the question to answer",
+                required = true,
+                example = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+        )
         @NotNull(message = "Question ID is required")
         UUID questionId,
 
+        @Schema(
+                description = "The actual response payload for the question",
+                required = true,
+                example = "{\"answer\":true}"
+        )
         @NotNull(message = "Response payload must not be null")
         JsonNode response
-) {
-}
+) {}

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/AttemptDetailsDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/AttemptDetailsDto.java
@@ -1,5 +1,6 @@
 package uk.gegc.quizmaker.dto.attempt;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gegc.quizmaker.model.attempt.AttemptMode;
 import uk.gegc.quizmaker.model.attempt.AttemptStatus;
 
@@ -7,14 +8,29 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
+@Schema(name = "AttemptDetailsDto", description = "Detailed information about an attempt, including answers")
 public record AttemptDetailsDto(
+        @Schema(description = "UUID of the attempt", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
         UUID attemptId,
+
+        @Schema(description = "UUID of the quiz", example = "1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f")
         UUID quizId,
+
+        @Schema(description = "UUID of the user", example = "9f8e7d6c-5b4a-3c2d-1b0a-9f8e7d6c5b4a")
         UUID userId,
+
+        @Schema(description = "Timestamp when the attempt was started", example = "2025-05-20T14:30:00Z")
         Instant startedAt,
+
+        @Schema(description = "Timestamp when the attempt was completed", example = "2025-05-20T14:45:00Z")
         Instant completedAt,
+
+        @Schema(description = "Final status of the attempt", example = "COMPLETED")
         AttemptStatus status,
+
+        @Schema(description = "Mode of the attempt", example = "ALL_AT_ONCE")
         AttemptMode mode,
+
+        @Schema(description = "List of submitted answers")
         List<AnswerSubmissionDto> answers
-) {
-}
+) {}

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/AttemptDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/AttemptDto.java
@@ -1,16 +1,29 @@
 package uk.gegc.quizmaker.dto.attempt;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gegc.quizmaker.model.attempt.AttemptMode;
 import uk.gegc.quizmaker.model.attempt.AttemptStatus;
 
 import java.time.Instant;
 import java.util.UUID;
 
+@Schema(name = "AttemptDto", description = "Summary information for an attempt")
 public record AttemptDto(
+        @Schema(description = "UUID of the attempt", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
         UUID attemptId,
+
+        @Schema(description = "UUID of the quiz", example = "1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f")
         UUID quizId,
+
+        @Schema(description = "UUID of the user", example = "9f8e7d6c-5b4a-3c2d-1b0a-9f8e7d6c5b4a")
         UUID userId,
+
+        @Schema(description = "Timestamp when the attempt was started", example = "2025-05-20T14:30:00Z")
         Instant startedAt,
+
+        @Schema(description = "Current status of the attempt", example = "IN_PROGRESS")
         AttemptStatus status,
-        AttemptMode mode) {
-}
+
+        @Schema(description = "Mode of the attempt", example = "ALL_AT_ONCE")
+        AttemptMode mode
+) {}

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/AttemptResultDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/AttemptResultDto.java
@@ -1,18 +1,36 @@
 package uk.gegc.quizmaker.dto.attempt;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
-
+@Schema(name = "AttemptResultDto", description = "Summary of results after completing an attempt")
 public record AttemptResultDto(
+        @Schema(description = "UUID of the attempt", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
         UUID attemptId,
+
+        @Schema(description = "UUID of the quiz", example = "1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f")
         UUID quizId,
+
+        @Schema(description = "UUID of the user", example = "9f8e7d6c-5b4a-3c2d-1b0a-9f8e7d6c5b4a")
         UUID userId,
+
+        @Schema(description = "Timestamp when the attempt was started", example = "2025-05-20T14:30:00Z")
         Instant startedAt,
+
+        @Schema(description = "Timestamp when the attempt was completed", example = "2025-05-20T14:45:00Z")
         Instant completedAt,
+
+        @Schema(description = "Total score achieved", example = "5.0")
         Double totalScore,
+
+        @Schema(description = "Number of correct answers", example = "5")
         Integer correctCount,
+
+        @Schema(description = "Total number of questions", example = "5")
         Integer totalQuestions,
+
+        @Schema(description = "Detailed answers submitted")
         List<AnswerSubmissionDto> answers
-) {
-}
+) {}

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/BatchAnswerSubmissionRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/BatchAnswerSubmissionRequest.java
@@ -1,12 +1,14 @@
 package uk.gegc.quizmaker.dto.attempt;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 
 import java.util.List;
 
+@Schema(name = "BatchAnswerSubmissionRequest", description = "Payload for submitting multiple answers at once")
 public record BatchAnswerSubmissionRequest(
+        @Schema(description = "List of answers to submit", required = true)
         @NotEmpty(message = "At least one answer must be submitted")
         List<@Valid AnswerSubmissionRequest> answers
-) {
-}
+) {}

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/StartAttemptRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/StartAttemptRequest.java
@@ -1,10 +1,12 @@
 package uk.gegc.quizmaker.dto.attempt;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import uk.gegc.quizmaker.model.attempt.AttemptMode;
 
+@Schema(name = "StartAttemptRequest", description = "Request to start a quiz attempt with a specific mode", example = "{\"mode\":\"ONE_BY_ONE\"}")
 public record StartAttemptRequest(
+        @Schema(description = "Mode in which to take the attempt", required = true)
         @NotNull(message = "Mode must be provided")
         AttemptMode mode
-) {
-}
+) {}

--- a/src/main/java/uk/gegc/quizmaker/dto/auth/JwtResponse.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/auth/JwtResponse.java
@@ -1,9 +1,18 @@
 package uk.gegc.quizmaker.dto.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "JwtResponse", description = "JSON Web Tokens and expiration information")
 public record JwtResponse(
+        @Schema(description = "Access token (JWT)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
         String accessToken,
+
+        @Schema(description = "Refresh token (JWT)", example = "dGhpc2lzYXJlZnJlc2h0b2tlbg==")
         String refreshToken,
+
+        @Schema(description = "Access token validity in milliseconds", example = "3600000")
         long accessExpiresInMs,
+
+        @Schema(description = "Refresh token validity in milliseconds", example = "864000000")
         long refreshExpiresInMs
-) {
-}
+) {}

--- a/src/main/java/uk/gegc/quizmaker/dto/auth/LoginRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/auth/LoginRequest.java
@@ -1,12 +1,15 @@
 package uk.gegc.quizmaker.dto.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(name = "LoginRequest", description = "Payload for user login")
 public record LoginRequest(
+        @Schema(description = "Username or email", example = "newUser")
         @NotBlank(message = "Username must not be blank")
         String username,
 
+        @Schema(description = "User password", example = "P@ssw0rd!")
         @NotBlank(message = "Password must not be blank")
         String password
-        ) {
-}
+) {}

--- a/src/main/java/uk/gegc/quizmaker/dto/auth/RefreshRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/auth/RefreshRequest.java
@@ -1,6 +1,10 @@
 package uk.gegc.quizmaker.dto.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "RefreshToken", description = "Payload to refresh an access token")
 public record RefreshRequest(
+        @Schema(description = "Refresh token to exchange", example = "dGhpc2lzYXJlZnJlc2h0b2tlbg==")
         String refreshToken
 ) {
 }

--- a/src/main/java/uk/gegc/quizmaker/dto/auth/RegisterRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/auth/RegisterRequest.java
@@ -1,20 +1,24 @@
 package uk.gegc.quizmaker.dto.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(name = "RegisterRequest", description = "Payload for user registration")
 public record RegisterRequest(
+        @Schema(description = "Unique username", example = "newUser")
         @NotBlank(message = "Username must not be blank")
         @Size(min = 4, max = 20, message = "Username must be between 4 and 20 characters")
         String username,
 
+        @Schema(description = "User email address", example = "user@example.com")
         @NotBlank(message = "Email must not be blank")
         @Email(message = "Email must be a valid address")
         String email,
 
+        @Schema(description = "Password for the new account", example = "P@ssw0rd!")
         @NotBlank(message = "Password must not be blank")
         @Size(min = 8, max = 100, message = "Password length must be at least 8 characters")
         String password
-) {
-}
+) {}

--- a/src/main/java/uk/gegc/quizmaker/dto/category/CategoryDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/category/CategoryDto.java
@@ -1,7 +1,16 @@
 package uk.gegc.quizmaker.dto.category;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.UUID;
+@Schema(description = "Category DTO")
+public record CategoryDto(
+        @Schema(description = "Category ID", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
+        UUID id,
 
-public record CategoryDto(UUID id, String name, String description) {
+        @Schema(description = "Category name", example = "General")
+        String name,
 
-}
+        @Schema(description = "Category description", example = "General knowledge topics")
+        String description
+) { }

--- a/src/main/java/uk/gegc/quizmaker/dto/category/CreateCategoryRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/category/CreateCategoryRequest.java
@@ -1,12 +1,24 @@
 package uk.gegc.quizmaker.dto.category;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "Request payload for creating a new category")
 public record CreateCategoryRequest(
+        @Schema(
+                description = "Name of the category",
+                example = "Science",
+                minLength = 3,
+                maxLength = 100
+        )
         @Size(min = 3, max = 100, message = "Category name length must be between 3 and 100 characters")
         String name,
 
+        @Schema(
+                description = "Description of the category",
+                example = "All science-related quizzes",
+                maxLength = 1000
+        )
         @Size(max = 1000, message = "Category description must be less than 1000 characters")
         String description
-) {
-}
+) { }

--- a/src/main/java/uk/gegc/quizmaker/dto/category/UpdateCategoryRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/category/UpdateCategoryRequest.java
@@ -1,12 +1,24 @@
 package uk.gegc.quizmaker.dto.category;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "Request payload for updating an existing category")
 public record UpdateCategoryRequest(
+        @Schema(
+                description = "Updated name of the category",
+                example = "History",
+                minLength = 3,
+                maxLength = 100
+        )
         @Size(min = 3, max = 100, message = "Category name length must be between 3 and 100 characters")
         String name,
 
+        @Schema(
+                description = "Updated description of the category",
+                example = "Historical events and figures",
+                maxLength = 1000
+        )
         @Size(max = 1000, message = "Category description must be less than 1000 characters")
         String description
-) {
-}
+) { }

--- a/src/main/java/uk/gegc/quizmaker/dto/question/CreateQuestionRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/question/CreateQuestionRequest.java
@@ -1,6 +1,7 @@
 package uk.gegc.quizmaker.dto.question;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -12,35 +13,65 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+@Schema(
+        name = "CreateQuestionRequest",
+        description = "Payload for creating a new question"
+)
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class CreateQuestionRequest implements QuestionContentRequest {
-    @NotNull(message = "Type must not be null")
-    QuestionType type;
 
+    @Schema(description = "Type of the question", required = true, example = "TRUE_FALSE")
+    @NotNull(message = "Type must not be null")
+    private QuestionType type;
+
+    @Schema(description = "Difficulty level", required = true, example = "EASY")
     @NotNull(message = "Difficulty must not be null")
     private Difficulty difficulty;
 
+    @Schema(
+            description = "Question text",
+            required = true,
+            example = "What is the capital of France?"
+    )
     @NotBlank(message = "Question text must not be blank")
     @Size(min = 3, max = 1000, message = "Question text length must be between 3 and 1000 characters")
     private String questionText;
 
+    @Schema(
+            description = "Content JSON specific to the question type",
+            required = true,
+            type = "object"
+    )
     @NotNull(message = "Content must not be null")
     private JsonNode content;
 
+    @Schema(description = "Optional hint for the question", example = "Think of the Eiffel Tower")
     @Size(max = 500, message = "Hint length must be less than 500 characters")
     private String hint;
 
+    @Schema(description = "Optional explanation for the answer", example = "Paris is the capital of France.")
     @Size(max = 2000, message = "Explanation must be less than 2000 characters")
     private String explanation;
 
+    @Schema(
+            description = "Optional URL for an attachment",
+            example = "http://example.com/image.png"
+    )
     @Size(max = 2048, message = "URL length is limited by 2048 characters")
     private String attachmentUrl;
 
+    @Schema(
+            description = "List of quiz IDs to associate this question with",
+            example = "[\"3fa85f64-5717-4562-b3fc-2c963f66afa6\"]"
+    )
     private List<UUID> quizIds = new ArrayList<>();
 
+    @Schema(
+            description = "List of tag IDs to associate this question with",
+            example = "[\"3fa85f64-5717-4562-b3fc-2c963f66afb7\"]"
+    )
     private List<UUID> tagIds = new ArrayList<>();
-
 }

--- a/src/main/java/uk/gegc/quizmaker/dto/question/QuestionDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/question/QuestionDto.java
@@ -1,6 +1,7 @@
 package uk.gegc.quizmaker.dto.question;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 import uk.gegc.quizmaker.model.question.Difficulty;
@@ -10,20 +11,53 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
+@Schema(
+        name = "QuestionDto",
+        description = "Data transfer object representing a question"
+)
 @Getter
 @Setter
 public class QuestionDto {
 
+    @Schema(description = "UUID of the question", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
     private UUID id;
+
+    @Schema(description = "Question type", example = "MCQ_SINGLE")
     private QuestionType type;
+
+    @Schema(description = "Difficulty level", example = "MEDIUM")
     private Difficulty difficulty;
+
+    @Schema(description = "Question text", example = "Select the correct option:")
     private String questionText;
+
+    @Schema(description = "Content JSON for this question", type = "object")
     private JsonNode content;
+
+    @Schema(description = "Optional hint text", example = "Remember the order")
     private String hint;
+
+    @Schema(description = "Optional explanation text", example = "Because that option matches the criteria")
     private String explanation;
+
+    @Schema(description = "Optional attachment URL", example = "http://example.com/diagram.png")
     private String attachmentUrl;
+
+    @Schema(description = "Timestamp when created", example = "2025-05-21T14:30:00Z")
     private Instant createdAt;
+
+    @Schema(description = "Timestamp when last updated", example = "2025-05-22T09:15:00Z")
     private Instant updatedAt;
+
+    @Schema(
+            description = "List of associated quiz UUIDs",
+            example = "[\"3fa85f64-5717-4562-b3fc-2c963f66afa6\"]"
+    )
     private List<UUID> quizIds;
+
+    @Schema(
+            description = "List of associated tag UUIDs",
+            example = "[\"3fa85f64-5717-4562-b3fc-2c963f66afb7\"]"
+    )
     private List<UUID> tagIds;
 }

--- a/src/main/java/uk/gegc/quizmaker/dto/question/UpdateQuestionRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/question/UpdateQuestionRequest.java
@@ -1,6 +1,7 @@
 package uk.gegc.quizmaker.dto.question;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -13,33 +14,65 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-
+@Schema(
+        name = "UpdateQuestionRequest",
+        description = "Payload for updating an existing question"
+)
 @Getter
 @Setter
 public class UpdateQuestionRequest implements QuestionContentRequest {
-    @NotNull(message = "Type must not be null")
-    QuestionType type;
 
+    @Schema(description = "Type of the question", required = true, example = "OPEN")
+    @NotNull(message = "Type must not be null")
+    private QuestionType type;
+
+    @Schema(description = "Difficulty level", required = true, example = "HARD")
     @NotNull(message = "Difficulty must not be null")
     private Difficulty difficulty;
 
+    @Schema(
+            description = "Question text",
+            required = true,
+            example = "Explain the theory of relativity"
+    )
     @NotBlank(message = "Question text must not be blank")
     @Size(min = 3, max = 1000, message = "Question text length must be between 3 and 1000 characters")
     private String questionText;
 
+    @Schema(
+            description = "Content JSON specific to the question type",
+            required = true,
+            type = "object"
+    )
     @NotNull(message = "Content must not be null")
     private JsonNode content;
 
+    @Schema(description = "Optional hint for the question", example = "Consider E=mc^2")
     @Size(max = 500, message = "Hint length must be less than 500 characters")
     private String hint;
 
+    @Schema(description = "Optional explanation for the answer", example = "Mass–energy equivalence")
     @Size(max = 2000, message = "Explanation must be less than 2000 characters")
     private String explanation;
 
+    @Schema(
+            description = "Optional URL for an attachment",
+            example = "http://example.com/figure.png"
+    )
     @Size(max = 2048, message = "URL length is limited by 2048 characters")
     private String attachmentUrl;
 
+    @Schema(
+            description = "List of quiz IDs to re-associate this question with",
+            example = "[\"3fa85f64-5717-4562-b3fc-2c963f66afa6\"]"
+    )
     private List<UUID> quizIds = new ArrayList<>();
 
+    @Schema(
+            description = "List of tag IDs to re-associate this question with",
+            example = "[\"3fa85f64-5717-4562-b3fc-2c963f66afb7\"]"
+    )
     private List<UUID> tagIds = new ArrayList<>();
+
+    // getters/setters...
 }

--- a/src/main/java/uk/gegc/quizmaker/dto/quiz/CreateQuizRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/quiz/CreateQuizRequest.java
@@ -1,5 +1,6 @@
 package uk.gegc.quizmaker.dto.quiz;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -10,29 +11,43 @@ import uk.gegc.quizmaker.model.quiz.Visibility;
 import java.util.List;
 import java.util.UUID;
 
-
+@Schema(name = "CreateQuizRequest", description = "Payload for creating a quiz")
 public record CreateQuizRequest(
+        @Schema(description = "Title of the quiz", example = "My Quiz")
         @NotBlank(message = "Title must not be blank")
         @Size(min = 3, max = 100, message = "Title length must be between 3 and 100 characters")
         String title,
 
+        @Schema(description = "Detailed description", example = "A fun pop-quiz")
         @Size(max = 1000, message = "Description must be at most 1000 characters long")
         String description,
 
+        @Schema(description = "Visibility of quiz (defaults PRIVATE)")
         Visibility visibility,
+
+        @Schema(description = "Difficulty level (defaults MEDIUM)")
         Difficulty difficulty,
+
+        @Schema(description = "Repetition enabled?")
         boolean isRepetitionEnabled,
+
+        @Schema(description = "Timer enabled?")
         boolean timerEnabled,
 
+        @Schema(description = "Estimated time in minutes", example = "10")
         @Min(value = 1, message = "Estimated time can't be less than 1 minute")
         @Max(value = 180, message = "Estimated time can't be more than 180 minutes")
         int estimatedTime,
 
+        @Schema(description = "Timer duration in minutes", example = "5")
         @Min(value = 1, message = "Timer duration must be at least 1 minute")
         @Max(value = 180, message = "Timer duration must be at most 180 minutes")
         int timerDuration,
 
+        @Schema(description = "Category UUID", example = "d290f1ee-6c54-4b01-90e6-d701748f0851")
         UUID categoryId,
+
+        @Schema(description = "List of tag UUIDs", example = "[\"a1b2c3d4-...\", \"e5f6g7h8-...\"]")
         List<UUID> tagIds
 ) {
     public CreateQuizRequest {

--- a/src/main/java/uk/gegc/quizmaker/dto/quiz/QuizDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/quiz/QuizDto.java
@@ -1,5 +1,6 @@
 package uk.gegc.quizmaker.dto.quiz;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gegc.quizmaker.model.question.Difficulty;
 import uk.gegc.quizmaker.model.quiz.Visibility;
 
@@ -7,20 +8,52 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
+@Schema(name = "QuizDto", description = "Representation of a quiz")
 public record QuizDto(
+
+        @Schema(description = "Quiz UUID", example = "d290f1ee-6c54-4b01-90e6-d701748f0851")
         UUID id,
+
+        @Schema(description = "Creator user UUID", example = "123e4567-e89b-12d3-a456-426614174000")
         UUID creatorId,
+
+        @Schema(description = "Category UUID", example = "d290f1ee-6c54-4b01-90e6-d701748f0851")
         UUID categoryId,
+
+        @Schema(description = "Title of the quiz", example = "My Sample Quiz")
         String title,
+
+        @Schema(description = "Description", example = "This quiz covers general knowledge questions.")
         String description,
+
+        @Schema(description = "Visibility", example = "PRIVATE")
         Visibility visibility,
+
+        @Schema(description = "Difficulty", example = "MEDIUM")
         Difficulty difficulty,
+
+        @Schema(description = "Estimated time in minutes", example = "15")
         Integer estimatedTime,
+
+        @Schema(description = "Is repetition enabled?", example = "false")
         Boolean isRepetitionEnabled,
+
+        @Schema(description = "Is timer enabled?", example = "true")
         Boolean timerEnabled,
+
+        @Schema(description = "Timer duration in minutes", example = "10")
         Integer timerDuration,
+
+        @Schema(
+                description = "List of tag UUIDs attached to the quiz",
+                example = "[\"a1b2c3d4-0000-0000-0000-000000000000\"]"
+        )
         List<UUID> tagIds,
+
+        @Schema(description = "Timestamp when the quiz was created", example = "2025-05-01T15:30:00Z")
         Instant createdAt,
+
+        @Schema(description = "Timestamp when the quiz was last updated", example = "2025-05-10T12:00:00Z")
         Instant updatedAt
-) {
-}
+
+) {}

--- a/src/main/java/uk/gegc/quizmaker/dto/quiz/QuizSearchCriteria.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/quiz/QuizSearchCriteria.java
@@ -1,14 +1,51 @@
 package uk.gegc.quizmaker.dto.quiz;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gegc.quizmaker.model.question.Difficulty;
 
 import java.util.List;
 
+@Schema(name = "QuizSearchCriteria", description = "Filter criteria for listing quizzes")
 public record QuizSearchCriteria(
+
+        @Parameter(
+                in = ParameterIn.QUERY,
+                name = "category",
+                description = "Filter by category names (comma‐delimited)"
+        )
+        @ArraySchema(schema = @Schema(type = "string"))
         List<String> category,
+
+        @Parameter(
+                in = ParameterIn.QUERY,
+                name = "tag",
+                description = "Filter by tag names (comma‐delimited)"
+        )
+        @ArraySchema(schema = @Schema(type = "string"))
         List<String> tag,
+
+        @Parameter(
+                in = ParameterIn.QUERY,
+                name = "authorName",
+                description = "Filter by author username"
+        )
         String authorName,
+
+        @Parameter(
+                in = ParameterIn.QUERY,
+                name = "search",
+                description = "Full‐text search on title/description"
+        )
         String search,
+
+        @Parameter(
+                in = ParameterIn.QUERY,
+                name = "difficulty",
+                description = "Filter by quiz difficulty"
+        )
         Difficulty difficulty
-) {
-}
+
+) {}

--- a/src/main/java/uk/gegc/quizmaker/dto/quiz/UpdateQuizRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/quiz/UpdateQuizRequest.java
@@ -1,5 +1,6 @@
 package uk.gegc.quizmaker.dto.quiz;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -10,28 +11,73 @@ import uk.gegc.quizmaker.model.quiz.Visibility;
 import java.util.List;
 import java.util.UUID;
 
+@Schema(name = "UpdateQuizRequest", description = "Fields to update on an existing quiz")
 public record UpdateQuizRequest(
+
+        @Schema(
+                description = "New title of the quiz",
+                example = "Updated Quiz Title"
+        )
         @Size(min = 3, max = 100, message = "Title length must be between 3 and 100 characters")
         String title,
 
+        @Schema(
+                description = "New detailed description",
+                example = "A revised description explaining the quiz purpose."
+        )
         @Size(max = 1000, message = "Description must be at most 1000 characters long")
         String description,
 
+        @Schema(
+                description = "New visibility setting",
+                example = "PUBLIC"
+        )
         Visibility visibility,
+
+        @Schema(
+                description = "New difficulty level",
+                example = "HARD"
+        )
         Difficulty difficulty,
 
+        @Schema(
+                description = "Enable or disable repetition",
+                example = "true"
+        )
         Boolean isRepetitionEnabled,
+
+        @Schema(
+                description = "Enable or disable timer",
+                example = "false"
+        )
         Boolean timerEnabled,
 
+        @Schema(
+                description = "New estimated time in minutes",
+                example = "20"
+        )
         @Min(value = 1, message = "Estimated time must be at least 1 minute")
         @Max(value = 180, message = "Estimated time must be at most 180 minutes")
         Integer estimatedTime,
 
+        @Schema(
+                description = "New timer duration in minutes",
+                example = "5"
+        )
         @Min(value = 1, message = "Timer duration must be at least 1 minute")
         @Max(value = 180, message = "Timer duration must be at most 180 minutes")
         Integer timerDuration,
 
+        @Schema(
+                description = "UUID of the new category",
+                example = "d290f1ee-6c54-4b01-90e6-d701748f0851"
+        )
         UUID categoryId,
+
+        @Schema(
+                description = "List of new tag UUIDs",
+                example = "[\"a1b2c3d4-0000-0000-0000-000000000000\", \"e5f6g7h8-1111-1111-1111-111111111111\"]"
+        )
         List<UUID> tagIds
-) {
-}
+
+) {}

--- a/src/main/java/uk/gegc/quizmaker/dto/tag/CreateTagRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/tag/CreateTagRequest.java
@@ -1,12 +1,15 @@
 package uk.gegc.quizmaker.dto.tag;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "Request payload to create a new tag")
 public record CreateTagRequest(
+        @Schema(description = "Name of the tag", example = "science")
         @Size(min = 3, max = 50, message = "Tag length must be between 3 and 50 characters")
         String name,
 
+        @Schema(description = "Optional description", example = "Questions about scientific topics")
         @Size(max = 1000, message = "Category description must be less than 1000 characters")
         String description
-) {
-}
+) {}

--- a/src/main/java/uk/gegc/quizmaker/dto/tag/TagDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/tag/TagDto.java
@@ -1,6 +1,17 @@
 package uk.gegc.quizmaker.dto.tag;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.UUID;
 
-public record TagDto(UUID id, String name, String description) {
-}
+@Schema(description = "Data Transfer Object for Tag")
+public record TagDto(
+        @Schema(description = "Unique identifier of the tag", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
+        UUID id,
+
+        @Schema(description = "Name of the tag", example = "math")
+        String name,
+
+        @Schema(description = "Optional description of the tag", example = "Questions related to mathematics")
+        String description
+) {}

--- a/src/main/java/uk/gegc/quizmaker/dto/tag/UpdateTagRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/tag/UpdateTagRequest.java
@@ -1,12 +1,15 @@
 package uk.gegc.quizmaker.dto.tag;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "Request payload to update an existing tag")
 public record UpdateTagRequest(
+        @Schema(description = "New name for the tag", example = "history")
         @Size(min = 3, max = 50, message = "Tag length must be between 3 and 50 characters")
         String name,
 
+        @Schema(description = "New description for the tag", example = "Questions about historical events")
         @Size(max = 1000, message = "Tag description must be less than 1000 characters")
         String description
-) {
-}
+) {}

--- a/src/main/java/uk/gegc/quizmaker/dto/user/UserDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/user/UserDto.java
@@ -1,18 +1,35 @@
 package uk.gegc.quizmaker.dto.user;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gegc.quizmaker.model.user.RoleName;
 
 import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.UUID;
 
+@Schema(name = "UserDto", description = "Details of a user")
 public record UserDto(
+        @Schema(description = "Unique user identifier", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
         UUID id,
+
+        @Schema(description = "Username", example = "newUser")
         String username,
+
+        @Schema(description = "Email address", example = "user@example.com")
         String email,
+
+        @Schema(description = "Whether the user is active", example = "true")
         boolean isActive,
+
+        @Schema(description = "Assigned roles", example = "[\"ROLE_USER\"]")
         Set<RoleName> roles,
+
+        @Schema(description = "Account creation timestamp", example = "2025-05-21T15:30:00")
         LocalDateTime createdAt,
+
+        @Schema(description = "Last login timestamp", example = "2025-05-21T16:00:00")
         LocalDateTime lastLoginDate,
+
+        @Schema(description = "Last update timestamp", example = "2025-05-21T16:10:00")
         LocalDateTime updatedAt
 ) {}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,12 @@ logging.level.org.springframework.orm.jpa=DEBUG
 spring.config.import=optional:classpath:secret.properties
 jwt.access-expiration-ms=43200000
 jwt.refresh-expiration-ms=604800000
+
+# serve the raw OpenAPI JSON under /api/v1/docs
+springdoc.api-docs.path=/api/v1/docs
+
+# serve the Swagger-UI HTML under /api/v1/docs/swagger-ui.html
+springdoc.swagger-ui.path=/api/v1/docs/swagger-ui.html
+
+# point the UI itself at your new JSON location
+springdoc.swagger-ui.url=/api/v1/docs


### PR DESCRIPTION
Description:
This pull request introduces full OpenAPI (Swagger) support to the QuizMaker application, annotating all existing REST controllers and DTOs to generate a rich, interactive API specification and Swagger UI.

Key Changes (by commit):
	1.	Add OpenAPI documentation and config
	•	Introduced springdoc-openapi and related dependencies.
	•	Created SwaggerConfig to expose /v3/api-docs and serve the Swagger UI at /swagger-ui.html.
	•	Annotated QuizController endpoints with @Operation, @ParameterObject, @Schema, and related annotations.
	•	Documented all Quiz-related DTOs (CreateQuizRequest, UpdateQuizRequest, QuizDto, QuizSearchCriteria) with @Schema and @Parameter (including comma-delimited array support via @ArraySchema).
	2.	Document AuthController and DTOs
	•	Annotated AuthController endpoints with @Tag, @Operation, @ApiResponses, and @Parameter.
	•	Enhanced request/response models (RegisterRequest, LoginRequest, JwtResponse, RefreshRequest, UserDto) with @Schema metadata and example values.
	3.	Document AttemptController and related DTOs
	•	Added OpenAPI annotations (@Tag, @Operation, @ApiResponses, @Parameter) to AttemptController methods.
	•	Applied @Schema descriptions, examples, and constraints to all attempt-related request and response DTOs.
	•	Ensured pageable, path and query parameters are properly described for Swagger UI.
	4.	Document CategoryController and DTOs
	•	Annotated CategoryController methods with @Operation, @Parameter, @RequestBody, and @ParameterObject.
	•	Added @Schema and field-level metadata (examples, size constraints) to CategoryDto, CreateCategoryRequest, and UpdateCategoryRequest.
	•	Applied @ParameterObject for paginated GET endpoints.
	5.	Add OpenAPI/Swagger annotations to QuestionController and DTOs
	•	Decorated QuestionController with @Tag, @Operation, @ApiResponse, @Parameter, and @ParameterObject.
	•	Augmented CreateQuestionRequest, UpdateQuestionRequest, and QuestionDto with detailed @Schema descriptions and operation-level JSON examples via @Content + @ExampleObject.
	•	Secured admin-only endpoints with @SecurityRequirement(name = "bearerAuth").
	6.	Add OpenAPI/Swagger annotations to TagController and DTOs
	•	Annotated TagController with @Tag, @Operation, @ApiResponse for every endpoint.
	•	Secured admin operations with @SecurityRequirement(name = "bearerAuth").
	•	Applied @ParameterObject for pageable parameters.
	•	Enriched TagDto, CreateTagRequest, and UpdateTagRequest with @Schema metadata (descriptions, examples, constraints). 

Closes #38 