### PR TITLE
@gegcuk feat(utility): add public health-check endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,11 @@
             <version>2.8.8</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
     </dependencies>
 
     <!-- Build configuration -->

--- a/src/main/java/uk/gegc/quizmaker/config/SecurityConfig.java
+++ b/src/main/java/uk/gegc/quizmaker/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET,"/v3/api-docs/**").permitAll()
                         .requestMatchers(HttpMethod.GET,"/swagger-ui/**").permitAll()
                         .requestMatchers(HttpMethod.GET,"/api/v1/docs/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/health").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtTokenProvider),

--- a/src/main/java/uk/gegc/quizmaker/controller/UtilityController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/UtilityController.java
@@ -1,4 +1,48 @@
 package uk.gegc.quizmaker.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.health.HealthComponent;
+import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/api/v1")
+@Tag(name = "Utility", description = "Utility & administrative endpoints")
+@RequiredArgsConstructor
 public class UtilityController {
+
+    private final HealthEndpoint healthEndpoint;
+
+    @Operation(
+            summary     = "Health-check endpoint",
+            description = "Returns 200 with `{ \"status\": \"UP\" }` if the service is alive"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description  = "Always returns service health",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema    = @Schema(
+                                    implementation = HealthComponent.class,
+                                    example        = "{\"status\":\"UP\"}"
+                            )
+                    )
+            )
+    })
+    @GetMapping("/health")
+    public ResponseEntity<HealthComponent> health() {
+        return ResponseEntity.ok(healthEndpoint.health());
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,3 +28,6 @@ springdoc.swagger-ui.path=/api/v1/docs/swagger-ui.html
 
 # point the UI itself at your new JSON location
 springdoc.swagger-ui.url=/api/v1/docs
+
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=always


### PR DESCRIPTION
- Introduce `UtilityController` with `/api/v1/health`, delegating to Actuator’s `HealthEndpoint`
- Annotate with OpenAPI `@Tag`, `@Operation` and `@ApiResponses` (response schema `HealthComponent`, example `{"status":"UP"}`)
- Permit unauthenticated access to `/api/v1/health` in `SecurityConfig`
- Expose only `health` and `info` in Actuator (`management.endpoints.web.exposure.include=health,info`)
- Always show full health details (`management.endpoint.health.show-details=always`)

Closes #55 