### PR TITLE
@gegcuk feat(quiz): add status PATCH endpoint

### DIFF
--- a/src/main/java/uk/gegc/quizmaker/controller/QuizController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/QuizController.java
@@ -281,4 +281,41 @@ public class QuizController {
         );
         return ResponseEntity.ok(quizDto);
     }
+
+    @Operation(
+            summary = "Change quiz status",
+            description = "ADMIN only - switch a quiz between DRAFT and PUBLISHED",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = QuizStatusUpdateRequest.class))
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Quiz successfully updated",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuizDto.class))),
+                    @ApiResponse(responseCode = "400", description = "Validation failure or illegal status transition",
+                            content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "Unauthenticated",
+                            content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403", description = "Authenticated but not ADMIN",
+                            content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Quiz not found",
+                            content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class)))
+            }
+    )
+    @PatchMapping("/{quizId}/status")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<QuizDto> updateQuizStatus(
+            @Parameter(description = "UUID of the quiz to update", required = true)
+            @PathVariable UUID quizId,
+            @RequestBody @Valid QuizStatusUpdateRequest request,
+            Authentication authentication
+    ){
+        QuizDto quizDto = quizService.setStatus(
+                authentication.getName(),
+                quizId,
+                request.status()
+        );
+        return ResponseEntity.ok(quizDto);
+    }
 }

--- a/src/main/java/uk/gegc/quizmaker/controller/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/advice/GlobalExceptionHandler.java
@@ -64,6 +64,17 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         );
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleIllegalArgument(IllegalArgumentException exception){
+        return new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                "Bad request",
+                List.of(exception.getMessage())
+        );
+    }
+
     @ExceptionHandler(IllegalStateException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
     public ErrorResponse handleIllegalState(IllegalStateException ex) {

--- a/src/main/java/uk/gegc/quizmaker/dto/quiz/QuizDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/quiz/QuizDto.java
@@ -2,6 +2,7 @@ package uk.gegc.quizmaker.dto.quiz;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gegc.quizmaker.model.question.Difficulty;
+import uk.gegc.quizmaker.model.quiz.QuizStatus;
 import uk.gegc.quizmaker.model.quiz.Visibility;
 
 import java.time.Instant;
@@ -31,6 +32,9 @@ public record QuizDto(
 
         @Schema(description = "Difficulty", example = "MEDIUM")
         Difficulty difficulty,
+
+        @Schema(description = "Quiz status", example = "DRAFT")
+        QuizStatus status,
 
         @Schema(description = "Estimated time in minutes", example = "15")
         Integer estimatedTime,

--- a/src/main/java/uk/gegc/quizmaker/dto/quiz/QuizStatusUpdateRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/quiz/QuizStatusUpdateRequest.java
@@ -1,0 +1,13 @@
+package uk.gegc.quizmaker.dto.quiz;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import uk.gegc.quizmaker.model.quiz.QuizStatus;
+
+@Schema(description = "Payload to change quiz status")
+public record QuizStatusUpdateRequest(
+        @NotNull
+        @Schema(description = "Desired quiz status", example = "PUBLISHED")
+        QuizStatus status
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/mapper/QuizMapper.java
+++ b/src/main/java/uk/gegc/quizmaker/mapper/QuizMapper.java
@@ -6,6 +6,7 @@ import uk.gegc.quizmaker.dto.quiz.QuizDto;
 import uk.gegc.quizmaker.dto.quiz.UpdateQuizRequest;
 import uk.gegc.quizmaker.model.category.Category;
 import uk.gegc.quizmaker.model.quiz.Quiz;
+import uk.gegc.quizmaker.model.quiz.QuizStatus;
 import uk.gegc.quizmaker.model.tag.Tag;
 import uk.gegc.quizmaker.model.user.User;
 
@@ -24,6 +25,7 @@ public class QuizMapper {
         quiz.setDescription(req.description());
         quiz.setVisibility(req.visibility());
         quiz.setDifficulty(req.difficulty());
+        quiz.setStatus(QuizStatus.DRAFT);
         quiz.setEstimatedTime(req.estimatedTime());
         quiz.setIsRepetitionEnabled(req.isRepetitionEnabled());
         quiz.setIsTimerEnabled(req.timerEnabled());
@@ -74,6 +76,7 @@ public class QuizMapper {
                 quiz.getDescription(),
                 quiz.getVisibility(),
                 quiz.getDifficulty(),
+                quiz.getStatus(),
                 quiz.getEstimatedTime(),
                 quiz.getIsRepetitionEnabled(),
                 quiz.getIsTimerEnabled(),

--- a/src/main/java/uk/gegc/quizmaker/model/quiz/Quiz.java
+++ b/src/main/java/uk/gegc/quizmaker/model/quiz/Quiz.java
@@ -58,6 +58,9 @@ public class Quiz {
     @Column(name = "difficulty", nullable = false, length = 20)
     private Difficulty difficulty;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private QuizStatus status;
 
     @Column(name = "estimated_time_min", nullable = false)
     private Integer estimatedTime;
@@ -111,6 +114,9 @@ public class Quiz {
     public void prePersist() {
         if (isDeleted == null) {
             isDeleted = false;
+        }
+        if(status == null){
+            status = QuizStatus.DRAFT;
         }
     }
 

--- a/src/main/java/uk/gegc/quizmaker/model/quiz/QuizStatus.java
+++ b/src/main/java/uk/gegc/quizmaker/model/quiz/QuizStatus.java
@@ -1,0 +1,7 @@
+package uk.gegc.quizmaker.model.quiz;
+
+public enum QuizStatus {
+    PUBLISHED,
+    DRAFT,
+    ARCHIVED
+}

--- a/src/main/java/uk/gegc/quizmaker/service/quiz/QuizService.java
+++ b/src/main/java/uk/gegc/quizmaker/service/quiz/QuizService.java
@@ -6,6 +6,7 @@ import uk.gegc.quizmaker.dto.quiz.CreateQuizRequest;
 import uk.gegc.quizmaker.dto.quiz.QuizDto;
 import uk.gegc.quizmaker.dto.quiz.QuizSearchCriteria;
 import uk.gegc.quizmaker.dto.quiz.UpdateQuizRequest;
+import uk.gegc.quizmaker.model.quiz.QuizStatus;
 import uk.gegc.quizmaker.model.quiz.Visibility;
 
 import java.util.UUID;
@@ -33,4 +34,6 @@ public interface QuizService {
     void changeCategory(String username, UUID quizId, UUID categoryId);
 
     QuizDto setVisibility(String name, UUID quizId, Visibility visibility);
+
+    QuizDto setStatus(String name, UUID quizId, QuizStatus status);
 }

--- a/src/main/java/uk/gegc/quizmaker/service/quiz/impl/QuizServiceImpl.java
+++ b/src/main/java/uk/gegc/quizmaker/service/quiz/impl/QuizServiceImpl.java
@@ -15,6 +15,7 @@ import uk.gegc.quizmaker.exception.ResourceNotFoundException;
 import uk.gegc.quizmaker.mapper.QuizMapper;
 import uk.gegc.quizmaker.model.category.Category;
 import uk.gegc.quizmaker.model.quiz.Quiz;
+import uk.gegc.quizmaker.model.quiz.QuizStatus;
 import uk.gegc.quizmaker.model.quiz.Visibility;
 import uk.gegc.quizmaker.model.tag.Tag;
 import uk.gegc.quizmaker.model.user.User;
@@ -179,5 +180,18 @@ public class QuizServiceImpl implements QuizService {
         quiz.setVisibility(visibility);
 
         return quizMapper.toDto(quizRepository.save(quiz)) ;
+    }
+
+    @Override
+    public QuizDto setStatus(String username, UUID quizId, QuizStatus status) {
+        Quiz quiz = quizRepository.findByIdWithQuestions(quizId)
+                .orElseThrow(() -> new ResourceNotFoundException("Quiz " + quizId + " not found"));
+
+        if (status == QuizStatus.PUBLISHED && quiz.getQuestions().isEmpty()) {
+            throw new IllegalArgumentException("Cannot publish quiz without questions");
+        }
+
+        quiz.setStatus(status);
+        return quizMapper.toDto(quizRepository.save(quiz));
     }
 }


### PR DESCRIPTION
## Quiz Status Management Update

###  Features Implemented

- **Add `QuizStatus` enum**
  - Represents different states a quiz can be in (e.g., `DRAFT`, `PUBLISHED`, etc.)

- **Include `status` column in `Quiz` entity**
  - Stores the current state of the quiz

- **Default new quizzes to `DRAFT`**
  - Ensures all newly created quizzes are not published automatically

- **Expose `status` in `QuizDto`**
  - Makes the status visible in API responses

- **Introduce `StatusUpdateRequest` DTO**
  - Used to receive and validate status updates from the client

- **Extend mapper logic**
  - Maps `StatusUpdateRequest` to the `Quiz` entity

- **Implement `setStatus()` method in service**
  - Contains validation logic, e.g., only allow publishing if requirements are met

- **Map `IllegalArgumentException` to HTTP 400**
  - Centralized in the global exception handler for consistent error responses

- **New PATCH endpoint:** PATCH /api/v1/quizzes/{quizId}/status

  - Allows admins to change quiz status

- **Extend integration tests**
  - Covers status transitions and validation scenarios

