### PR TITLE
@gegcuk feat(quiz): add public quizzes endpoint

### DIFF
--- a/src/main/java/uk/gegc/quizmaker/controller/QuizController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/QuizController.java
@@ -318,4 +318,18 @@ public class QuizController {
         );
         return ResponseEntity.ok(quizDto);
     }
+
+    @Operation(
+            summary = "List public quizzes",
+            description = "Returns a paginated list of quizzes with PUBLIC visibility"
+    )
+    @GetMapping("/public")
+    public ResponseEntity<Page<QuizDto>> getPublicQuizzes(
+            @ParameterObject
+            @PageableDefault(page = 0, size = 20)
+            @SortDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        return ResponseEntity.ok(quizService.getPublicQuizzes(pageable));
+    }
 }

--- a/src/main/java/uk/gegc/quizmaker/repository/quiz/QuizRepository.java
+++ b/src/main/java/uk/gegc/quizmaker/repository/quiz/QuizRepository.java
@@ -1,10 +1,13 @@
 package uk.gegc.quizmaker.repository.quiz;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gegc.quizmaker.model.quiz.Quiz;
+import uk.gegc.quizmaker.model.quiz.Visibility;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -27,4 +30,6 @@ public interface QuizRepository extends JpaRepository<Quiz, UUID> {
       WHERE q.id = :id AND q.isDeleted = false
     """)
     Optional<Quiz> findByIdWithQuestions(@Param("id") UUID id);
+
+    Page<Quiz>  findAllByVisibility(Visibility visibility, Pageable pageable);
 }

--- a/src/main/java/uk/gegc/quizmaker/service/quiz/QuizService.java
+++ b/src/main/java/uk/gegc/quizmaker/service/quiz/QuizService.java
@@ -36,4 +36,6 @@ public interface QuizService {
     QuizDto setVisibility(String name, UUID quizId, Visibility visibility);
 
     QuizDto setStatus(String name, UUID quizId, QuizStatus status);
+
+    Page<QuizDto> getPublicQuizzes(Pageable pageable);
 }

--- a/src/main/java/uk/gegc/quizmaker/service/quiz/impl/QuizServiceImpl.java
+++ b/src/main/java/uk/gegc/quizmaker/service/quiz/impl/QuizServiceImpl.java
@@ -194,4 +194,11 @@ public class QuizServiceImpl implements QuizService {
         quiz.setStatus(status);
         return quizMapper.toDto(quizRepository.save(quiz));
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<QuizDto> getPublicQuizzes(Pageable pageable) {
+        return quizRepository.findAllByVisibility(Visibility.PUBLIC, pageable)
+                .map(quizMapper::toDto);
+    }
 }


### PR DESCRIPTION
                    - Implement GET `/api/v1/quizzes/public` in `QuizController`
                    - Add `getPublicQuizzes` to `QuizService` and implement in `QuizServiceImpl`
                    - Extend `QuizRepository` with `findAllByVisibility`
                    - Integrate public quiz integration tests into `QuizControllerIntegrationTest`

Closes #67 