### PR TITLE
@gegcuk feat(quiz): add bulk quiz update endpoint

### DIFF
--- a/src/main/java/uk/gegc/quizmaker/controller/QuizController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/QuizController.java
@@ -118,6 +118,25 @@ public class QuizController {
     }
 
     @Operation(
+            summary = "Bulk update quizzes",
+            description = "ADMIN only. Update multiple quizzes in one request."
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Bulk update payload",
+            required = true,
+            content = @Content(schema = @Schema(implementation = BulkQuizUpdateRequest.class))
+    )
+    @PatchMapping("/bulk-update")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<BulkQuizUpdateOperationResultDto> bulkUpdateQuizzes(
+            @RequestBody @Valid BulkQuizUpdateRequest request,
+            Authentication authentication
+    ){
+        BulkQuizUpdateOperationResultDto resultDto = quizService.bulkUpdateQuiz(authentication.getName(), request);
+        return ResponseEntity.ok(resultDto);
+    }
+
+    @Operation(
             summary = "Delete a quiz",
             description = "ADMIN only. Permanently deletes the quiz."
     )

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/AnswerSubmissionRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/AnswerSubmissionRequest.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 public record AnswerSubmissionRequest(
         @Schema(
                 description = "UUID of the question to answer",
-                required = true,
+                requiredMode = Schema.RequiredMode.REQUIRED,
                 example = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
         )
         @NotNull(message = "Question ID is required")
@@ -21,7 +21,7 @@ public record AnswerSubmissionRequest(
 
         @Schema(
                 description = "The actual response payload for the question",
-                required = true,
+                requiredMode = Schema.RequiredMode.REQUIRED,
                 example = "{\"answer\":true}"
         )
         @NotNull(message = "Response payload must not be null")

--- a/src/main/java/uk/gegc/quizmaker/dto/question/CreateQuestionRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/question/CreateQuestionRequest.java
@@ -23,17 +23,17 @@ import java.util.UUID;
 @NoArgsConstructor
 public class CreateQuestionRequest implements QuestionContentRequest {
 
-    @Schema(description = "Type of the question", required = true, example = "TRUE_FALSE")
+    @Schema(description = "Type of the question", requiredMode = Schema.RequiredMode.REQUIRED, example = "TRUE_FALSE")
     @NotNull(message = "Type must not be null")
     private QuestionType type;
 
-    @Schema(description = "Difficulty level", required = true, example = "EASY")
+    @Schema(description = "Difficulty level", requiredMode = Schema.RequiredMode.REQUIRED, example = "EASY")
     @NotNull(message = "Difficulty must not be null")
     private Difficulty difficulty;
 
     @Schema(
             description = "Question text",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "What is the capital of France?"
     )
     @NotBlank(message = "Question text must not be blank")
@@ -42,7 +42,7 @@ public class CreateQuestionRequest implements QuestionContentRequest {
 
     @Schema(
             description = "Content JSON specific to the question type",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             type = "object"
     )
     @NotNull(message = "Content must not be null")

--- a/src/main/java/uk/gegc/quizmaker/dto/quiz/BulkQuizUpdateOperationResultDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/quiz/BulkQuizUpdateOperationResultDto.java
@@ -1,0 +1,17 @@
+package uk.gegc.quizmaker.dto.quiz;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Schema(name = "BulkQuizUpdateOperationResultDto", description = "Outcome of a bulk operation")
+public record BulkQuizUpdateOperationResultDto(
+        @Schema(description = "IDs of quizzes successfully updated")
+        List<UUID> successfulIds,
+
+        @Schema(description = "Mapping of quiz IDs to failure reason")
+        Map<UUID, String> failures
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/quiz/BulkQuizUpdateRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/quiz/BulkQuizUpdateRequest.java
@@ -1,0 +1,23 @@
+package uk.gegc.quizmaker.dto.quiz;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+import java.util.UUID;
+
+@Schema(name = "BulkQuizUpdateRequest", description = "Request payload for updating multiple quizzes")
+public record BulkQuizUpdateRequest(
+        @Schema(description = "List of quiz IDs to update", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
+        @Size(min = 1, message = "At least one quizId must be provided")
+        List<UUID> quizIds,
+
+        @Schema(description = "Fields to update for all specified quizzes", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
+        @Valid
+        UpdateQuizRequest update
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/service/quiz/QuizService.java
+++ b/src/main/java/uk/gegc/quizmaker/service/quiz/QuizService.java
@@ -1,11 +1,9 @@
 package uk.gegc.quizmaker.service.quiz;
 
+import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import uk.gegc.quizmaker.dto.quiz.CreateQuizRequest;
-import uk.gegc.quizmaker.dto.quiz.QuizDto;
-import uk.gegc.quizmaker.dto.quiz.QuizSearchCriteria;
-import uk.gegc.quizmaker.dto.quiz.UpdateQuizRequest;
+import uk.gegc.quizmaker.dto.quiz.*;
 import uk.gegc.quizmaker.model.quiz.QuizStatus;
 import uk.gegc.quizmaker.model.quiz.Visibility;
 
@@ -41,4 +39,6 @@ public interface QuizService {
     Page<QuizDto> getPublicQuizzes(Pageable pageable);
 
     void deleteQuizzesByIds(String name, List<UUID> quizIds);
+
+    BulkQuizUpdateOperationResultDto bulkUpdateQuiz(String name, BulkQuizUpdateRequest request);
 }


### PR DESCRIPTION
**Summary**

- add BulkQuizUpdateRequest and BulkOperationResultDto

- extend QuizService with bulk update capability

- implement logic in QuizServiceImpl

- expose PATCH /api/v1/quizzes/bulk-update endpoint

- document the endpoint in Swagger and README

- replace deprecated required attributes with requiredMode

- test success and failure cases for bulk update