### PR TITLE
@gegcuk feat(quiz): add quiz leaderboard endpoint and tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,23 +69,7 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- JWT support (Java JSON Web Token library) -->
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-api</artifactId>
-            <version>0.12.5</version>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-impl</artifactId>
-            <version>0.12.5</version>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-jackson</artifactId>
-            <version>0.12.5</version>
-            <scope>runtime</scope>
-        </dependency>
+
 
         <!-- MySQL driver for production DB -->
         <dependency>

--- a/src/main/java/uk/gegc/quizmaker/config/DataInitializer.java
+++ b/src/main/java/uk/gegc/quizmaker/config/DataInitializer.java
@@ -15,9 +15,9 @@ public class DataInitializer implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
-        for(RoleName roleName: RoleName.values()){
+        for (RoleName roleName : RoleName.values()) {
             String name = roleName.name();
-            if(roleRepository.findByRole(name).isEmpty()) {
+            if (roleRepository.findByRole(name).isEmpty()) {
                 Role role = new Role();
                 role.setRole(name);
                 roleRepository.save(role);

--- a/src/main/java/uk/gegc/quizmaker/config/OpenApiConfig.java
+++ b/src/main/java/uk/gegc/quizmaker/config/OpenApiConfig.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Configuration;
 public class OpenApiConfig {
 
     @Bean
-    public OpenAPI quizMakerOpenApi(){
+    public OpenAPI quizMakerOpenApi() {
         return new OpenAPI()
                 .info(new Info()
                         .title("QuizMaker API")

--- a/src/main/java/uk/gegc/quizmaker/config/SecurityConfig.java
+++ b/src/main/java/uk/gegc/quizmaker/config/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception{
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -42,13 +42,13 @@ public class SecurityConfig {
                                 "/api/v1/auth/2fa/verify"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/auth/me").authenticated()
-                        .requestMatchers(HttpMethod.GET,"/api/v1/quizzes/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/quizzes/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/tags/**").permitAll()
-                        .requestMatchers(HttpMethod.GET,"/api/v1/categories/**").permitAll()
-                        .requestMatchers(HttpMethod.GET,"/api/v1/questions/**").permitAll()
-                        .requestMatchers(HttpMethod.GET,"/v3/api-docs/**").permitAll()
-                        .requestMatchers(HttpMethod.GET,"/swagger-ui/**").permitAll()
-                        .requestMatchers(HttpMethod.GET,"/api/v1/docs/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/categories/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/questions/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/v3/api-docs/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/swagger-ui/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/docs/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/health").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(
@@ -61,7 +61,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public PasswordEncoder passwordEncoder(){
+    public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 

--- a/src/main/java/uk/gegc/quizmaker/controller/AttemptController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/AttemptController.java
@@ -27,6 +27,7 @@ import uk.gegc.quizmaker.service.attempt.AttemptService;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
 @Tag(name = "Attempts", description = "Endpoints for managing quiz attempts")
 @RestController
 @RequestMapping("/api/v1/attempts")

--- a/src/main/java/uk/gegc/quizmaker/controller/CategoryController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/CategoryController.java
@@ -43,7 +43,7 @@ public class CategoryController {
     @Operation(
             summary = "List categories",
             description = "Get a paginated list of categories, sorted by name ascending",
-            tags = { "Categories" }
+            tags = {"Categories"}
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Page of categories returned")
@@ -61,7 +61,7 @@ public class CategoryController {
     @Operation(
             summary = "Create a category",
             description = "Create a new category. Requires ADMIN role.",
-            tags = { "Categories" }
+            tags = {"Categories"}
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "Category created"),
@@ -88,7 +88,7 @@ public class CategoryController {
     @Operation(
             summary = "Get category by ID",
             description = "Retrieve a category by its UUID",
-            tags = { "Categories" }
+            tags = {"Categories"}
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Category returned"),
@@ -105,7 +105,7 @@ public class CategoryController {
     @Operation(
             summary = "Update a category",
             description = "Update name and/or description of an existing category. Requires ADMIN role.",
-            tags = { "Categories" }
+            tags = {"Categories"}
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Category updated"),
@@ -136,7 +136,7 @@ public class CategoryController {
     @Operation(
             summary = "Delete a category",
             description = "Delete a category by its UUID. Requires ADMIN role.",
-            tags = { "Categories" }
+            tags = {"Categories"}
     )
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "Category deleted"),

--- a/src/main/java/uk/gegc/quizmaker/controller/QuestionController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/QuestionController.java
@@ -27,6 +27,7 @@ import uk.gegc.quizmaker.service.question.QuestionService;
 
 import java.util.Map;
 import java.util.UUID;
+
 @Tag(
         name = "Questions",
         description = "Operations for managing quiz questions"
@@ -41,7 +42,7 @@ public class QuestionController {
     @Operation(
             summary = "Create a question",
             description = "Add a new question (ADMIN only)",
-            tags = { "Questions" }
+            tags = {"Questions"}
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "Question created"),
@@ -68,7 +69,7 @@ public class QuestionController {
     @Operation(
             summary = "List questions",
             description = "Get a page of questions, optionally filtered by quizId",
-            tags = { "Questions" }
+            tags = {"Questions"}
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Page of questions returned")
@@ -103,7 +104,7 @@ public class QuestionController {
     @Operation(
             summary = "Get question by ID",
             description = "Retrieve a single question by its UUID",
-            tags = { "Questions" }
+            tags = {"Questions"}
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Question returned"),
@@ -120,7 +121,7 @@ public class QuestionController {
     @Operation(
             summary = "Update a question",
             description = "Modify an existing question (ADMIN only)",
-            tags = { "Questions" }
+            tags = {"Questions"}
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Question updated"),
@@ -151,7 +152,7 @@ public class QuestionController {
     @Operation(
             summary = "Delete a question",
             description = "Remove a question by its UUID (ADMIN only)",
-            tags = { "Questions" }
+            tags = {"Questions"}
     )
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "Question deleted"),

--- a/src/main/java/uk/gegc/quizmaker/controller/UtilityController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/UtilityController.java
@@ -24,18 +24,18 @@ public class UtilityController {
     private final HealthEndpoint healthEndpoint;
 
     @Operation(
-            summary     = "Health-check endpoint",
+            summary = "Health-check endpoint",
             description = "Returns 200 with `{ \"status\": \"UP\" }` if the service is alive"
     )
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
-                    description  = "Always returns service health",
+                    description = "Always returns service health",
                     content = @Content(
                             mediaType = "application/json",
-                            schema    = @Schema(
+                            schema = @Schema(
                                     implementation = HealthComponent.class,
-                                    example        = "{\"status\":\"UP\"}"
+                                    example = "{\"status\":\"UP\"}"
                             )
                     )
             )

--- a/src/main/java/uk/gegc/quizmaker/controller/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/advice/GlobalExceptionHandler.java
@@ -66,7 +66,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ErrorResponse handleIllegalArgument(IllegalArgumentException exception){
+    public ErrorResponse handleIllegalArgument(IllegalArgumentException exception) {
         return new ErrorResponse(
                 LocalDateTime.now(),
                 HttpStatus.BAD_REQUEST.value(),
@@ -119,7 +119,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         );
     }
 
-    @ExceptionHandler({ AccessDeniedException.class, AuthorizationDeniedException.class })
+    @ExceptionHandler({AccessDeniedException.class, AuthorizationDeniedException.class})
     @ResponseStatus(HttpStatus.FORBIDDEN)
     public ErrorResponse handleAccessDenied(Exception ex) {
         return new ErrorResponse(
@@ -200,5 +200,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             int status,
             String error,
             List<String> details
-    ) {}
+    ) {
+    }
 }

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/AnswerSubmissionDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/AnswerSubmissionDto.java
@@ -25,4 +25,5 @@ public record AnswerSubmissionDto(
 
         @Schema(description = "Next question in ONE_BY_ONE mode, if any")
         QuestionDto nextQuestion
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/AnswerSubmissionRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/AnswerSubmissionRequest.java
@@ -26,4 +26,5 @@ public record AnswerSubmissionRequest(
         )
         @NotNull(message = "Response payload must not be null")
         JsonNode response
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/AttemptDetailsDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/AttemptDetailsDto.java
@@ -33,4 +33,5 @@ public record AttemptDetailsDto(
 
         @Schema(description = "List of submitted answers")
         List<AnswerSubmissionDto> answers
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/AttemptDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/AttemptDto.java
@@ -26,4 +26,5 @@ public record AttemptDto(
 
         @Schema(description = "Mode of the attempt", example = "ALL_AT_ONCE")
         AttemptMode mode
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/AttemptResultDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/AttemptResultDto.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+
 @Schema(name = "AttemptResultDto", description = "Summary of results after completing an attempt")
 public record AttemptResultDto(
         @Schema(description = "UUID of the attempt", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
@@ -33,4 +34,5 @@ public record AttemptResultDto(
 
         @Schema(description = "Detailed answers submitted")
         List<AnswerSubmissionDto> answers
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/BatchAnswerSubmissionRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/BatchAnswerSubmissionRequest.java
@@ -11,4 +11,5 @@ public record BatchAnswerSubmissionRequest(
         @Schema(description = "List of answers to submit", required = true)
         @NotEmpty(message = "At least one answer must be submitted")
         List<@Valid AnswerSubmissionRequest> answers
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/StartAttemptRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/StartAttemptRequest.java
@@ -9,4 +9,5 @@ public record StartAttemptRequest(
         @Schema(description = "Mode in which to take the attempt", required = true)
         @NotNull(message = "Mode must be provided")
         AttemptMode mode
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/auth/JwtResponse.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/auth/JwtResponse.java
@@ -15,4 +15,5 @@ public record JwtResponse(
 
         @Schema(description = "Refresh token validity in milliseconds", example = "864000000")
         long refreshExpiresInMs
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/auth/LoginRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/auth/LoginRequest.java
@@ -12,4 +12,5 @@ public record LoginRequest(
         @Schema(description = "User password", example = "P@ssw0rd!")
         @NotBlank(message = "Password must not be blank")
         String password
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/auth/RegisterRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/auth/RegisterRequest.java
@@ -21,4 +21,5 @@ public record RegisterRequest(
         @NotBlank(message = "Password must not be blank")
         @Size(min = 8, max = 100, message = "Password length must be at least 8 characters")
         String password
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/category/CategoryDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/category/CategoryDto.java
@@ -3,6 +3,7 @@ package uk.gegc.quizmaker.dto.category;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.UUID;
+
 @Schema(description = "Category DTO")
 public record CategoryDto(
         @Schema(description = "Category ID", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
@@ -13,4 +14,5 @@ public record CategoryDto(
 
         @Schema(description = "Category description", example = "General knowledge topics")
         String description
-) { }
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/category/CreateCategoryRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/category/CreateCategoryRequest.java
@@ -21,4 +21,5 @@ public record CreateCategoryRequest(
         )
         @Size(max = 1000, message = "Category description must be less than 1000 characters")
         String description
-) { }
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/category/UpdateCategoryRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/category/UpdateCategoryRequest.java
@@ -21,4 +21,5 @@ public record UpdateCategoryRequest(
         )
         @Size(max = 1000, message = "Category description must be less than 1000 characters")
         String description
-) { }
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/question/CreateQuestionRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/question/CreateQuestionRequest.java
@@ -5,7 +5,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import uk.gegc.quizmaker.model.question.Difficulty;
 import uk.gegc.quizmaker.model.question.QuestionType;
 

--- a/src/main/java/uk/gegc/quizmaker/dto/quiz/QuizDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/quiz/QuizDto.java
@@ -60,4 +60,5 @@ public record QuizDto(
         @Schema(description = "Timestamp when the quiz was last updated", example = "2025-05-10T12:00:00Z")
         Instant updatedAt
 
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/quiz/QuizSearchCriteria.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/quiz/QuizSearchCriteria.java
@@ -48,4 +48,5 @@ public record QuizSearchCriteria(
         )
         Difficulty difficulty
 
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/quiz/UpdateQuizRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/quiz/UpdateQuizRequest.java
@@ -3,7 +3,6 @@ package uk.gegc.quizmaker.dto.quiz;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import uk.gegc.quizmaker.model.question.Difficulty;
 import uk.gegc.quizmaker.model.quiz.Visibility;
@@ -80,4 +79,5 @@ public record UpdateQuizRequest(
         )
         List<UUID> tagIds
 
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/quiz/VisibilityUpdateRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/quiz/VisibilityUpdateRequest.java
@@ -10,5 +10,6 @@ public record VisibilityUpdateRequest(
                 example = "true"
         )
         @NotNull Boolean isPublic
-) {}
+) {
+}
 

--- a/src/main/java/uk/gegc/quizmaker/dto/result/LeaderboardEntryDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/result/LeaderboardEntryDto.java
@@ -1,0 +1,18 @@
+package uk.gegc.quizmaker.dto.result;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(name = "LeaderboardEntryDto", description = "Quiz leaderboard entry")
+public record LeaderboardEntryDto(
+        @Schema(description = "User identifier")
+        UUID userId,
+
+        @Schema(description = "Username")
+        String username,
+
+        @Schema(description = "Best score for the quiz")
+        Double bestScore
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/result/QuestionStatsDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/result/QuestionStatsDto.java
@@ -7,4 +7,5 @@ public record QuestionStatsDto(
         long timesAsked,    // how many completed attempts included this question
         long timesCorrect,  // how many times it was answered correctly
         double correctRate  // (timesCorrect / timesAsked) * 100.0, or 0.0 if timesAsked==0
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/tag/CreateTagRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/tag/CreateTagRequest.java
@@ -12,4 +12,5 @@ public record CreateTagRequest(
         @Schema(description = "Optional description", example = "Questions about scientific topics")
         @Size(max = 1000, message = "Category description must be less than 1000 characters")
         String description
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/tag/TagDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/tag/TagDto.java
@@ -14,4 +14,5 @@ public record TagDto(
 
         @Schema(description = "Optional description of the tag", example = "Questions related to mathematics")
         String description
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/tag/UpdateTagRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/tag/UpdateTagRequest.java
@@ -12,4 +12,5 @@ public record UpdateTagRequest(
         @Schema(description = "New description for the tag", example = "Questions about historical events")
         @Size(max = 1000, message = "Tag description must be less than 1000 characters")
         String description
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/dto/user/UserDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/user/UserDto.java
@@ -32,4 +32,5 @@ public record UserDto(
 
         @Schema(description = "Last update timestamp", example = "2025-05-21T16:10:00")
         LocalDateTime updatedAt
-) {}
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/mapper/UserMapper.java
+++ b/src/main/java/uk/gegc/quizmaker/mapper/UserMapper.java
@@ -18,7 +18,7 @@ public class UserMapper {
     private final RoleRepository roleRepository;
     private final UserRepository userRepository;
 
-    public UserDto toDto(User user){
+    public UserDto toDto(User user) {
         return new UserDto(
                 user.getId(),
                 user.getUsername(),

--- a/src/main/java/uk/gegc/quizmaker/model/quiz/Quiz.java
+++ b/src/main/java/uk/gegc/quizmaker/model/quiz/Quiz.java
@@ -102,11 +102,11 @@ public class Quiz {
 
     @ManyToMany(
             fetch = FetchType.LAZY,
-            cascade = { CascadeType.PERSIST, CascadeType.MERGE }
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE}
     )
     @JoinTable(
             name = "quiz_questions",
-            joinColumns        = @JoinColumn(name = "quiz_id"),
+            joinColumns = @JoinColumn(name = "quiz_id"),
             inverseJoinColumns = @JoinColumn(name = "question_id"))
     private Set<Question> questions = new HashSet<>();
 
@@ -115,7 +115,7 @@ public class Quiz {
         if (isDeleted == null) {
             isDeleted = false;
         }
-        if(status == null){
+        if (status == null) {
             status = QuizStatus.DRAFT;
         }
     }

--- a/src/main/java/uk/gegc/quizmaker/model/user/User.java
+++ b/src/main/java/uk/gegc/quizmaker/model/user/User.java
@@ -17,7 +17,8 @@ import java.util.UUID;
 @Entity
 @Getter
 @Setter
-@NoArgsConstructor @AllArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "users")
 public class User implements Persistable<UUID> {
@@ -73,7 +74,8 @@ public class User implements Persistable<UUID> {
         return this.isNew;
     }
 
-    @PostLoad @PostPersist
+    @PostLoad
+    @PostPersist
     void markNotNew() {
         this.isNew = false;
     }
@@ -81,7 +83,7 @@ public class User implements Persistable<UUID> {
     @PrePersist
     void prePersist() {
         this.createdAt = LocalDateTime.now();
-        this.isNew     = true;
+        this.isNew = true;
     }
 
     @PreUpdate

--- a/src/main/java/uk/gegc/quizmaker/repository/attempt/AttemptRepository.java
+++ b/src/main/java/uk/gegc/quizmaker/repository/attempt/AttemptRepository.java
@@ -17,19 +17,19 @@ import java.util.UUID;
 public interface AttemptRepository extends JpaRepository<Attempt, UUID> {
 
     @Query(value = """
-        SELECT a
-        FROM Attempt a
-        JOIN FETCH a.quiz q
-        JOIN FETCH a.user u
-        WHERE (:quizId IS NULL OR q.id = :quizId)
-          AND (:userId IS NULL OR u.id = :userId)
-        """,
+            SELECT a
+            FROM Attempt a
+            JOIN FETCH a.quiz q
+            JOIN FETCH a.user u
+            WHERE (:quizId IS NULL OR q.id = :quizId)
+              AND (:userId IS NULL OR u.id = :userId)
+            """,
             countQuery = """
-        SELECT COUNT(a)
-        FROM Attempt a
-        WHERE (:quizId IS NULL OR a.quiz.id = :quizId)
-          AND (:userId IS NULL OR a.user.id = :userId)
-        """
+                    SELECT COUNT(a)
+                    FROM Attempt a
+                    WHERE (:quizId IS NULL OR a.quiz.id = :quizId)
+                      AND (:userId IS NULL OR a.user.id = :userId)
+                    """
     )
     Page<Attempt> findAllByQuizAndUserEager(
             @Param("quizId") UUID quizId,
@@ -38,32 +38,33 @@ public interface AttemptRepository extends JpaRepository<Attempt, UUID> {
     );
 
     @Query("""
-        SELECT a
-        FROM Attempt a
-        LEFT JOIN FETCH a.answers ans
-        LEFT JOIN FETCH ans.question q
-        WHERE a.id = :id
-        """)
+            SELECT a
+            FROM Attempt a
+            LEFT JOIN FETCH a.answers ans
+            LEFT JOIN FETCH ans.question q
+            WHERE a.id = :id
+            """)
     Optional<Attempt> findByIdWithAnswersAndQuestion(@Param("id") UUID id);
 
     @Query("""
-        SELECT a
-        FROM Attempt a
-        LEFT JOIN FETCH a.answers ans
-        LEFT JOIN FETCH ans.question q
-        LEFT JOIN FETCH a.quiz quiz
-        LEFT JOIN FETCH quiz.questions qlist
-        WHERE a.id = :id
-        """)
+            SELECT a
+            FROM Attempt a
+            LEFT JOIN FETCH a.answers ans
+            LEFT JOIN FETCH ans.question q
+            LEFT JOIN FETCH a.quiz quiz
+            LEFT JOIN FETCH quiz.questions qlist
+            WHERE a.id = :id
+            """)
     Optional<Attempt> findByIdWithAllRelations(@Param("id") UUID id);
 
     @Query("""
-        SELECT COUNT(a), AVG(a.totalScore), MAX(a.totalScore), MIN(a.totalScore)
-        FROM Attempt a
-        WHERE a.quiz.id = :quizId
-          AND a.status = 'COMPLETED'
-        """)
+            SELECT COUNT(a), AVG(a.totalScore), MAX(a.totalScore), MIN(a.totalScore)
+            FROM Attempt a
+            WHERE a.quiz.id = :quizId
+              AND a.status = 'COMPLETED'
+            """)
     List<Object[]> getAttemptAggregateData(@Param("quizId") UUID quizId);
+
     List<Attempt> findByQuiz_Id(UUID quizId);
 
     @EntityGraph(attributePaths = {
@@ -75,4 +76,14 @@ public interface AttemptRepository extends JpaRepository<Attempt, UUID> {
     @Query("SELECT a FROM Attempt a WHERE a.id = :id")
     Optional<Attempt> findFullyLoadedById(@Param("id") UUID id);
 
+    @Query("""
+        SELECT u.id, u.username, MAX(a.totalScore)
+        FROM Attempt a
+        JOIN a.user u
+        WHERE a.quiz.id = :quizId
+          AND a.status = 'COMPLETED'
+        GROUP BY u.id, u.username
+        ORDER BY MAX(a.totalScore) DESC
+        """)
+    List<Object[]> getLeaderboardData(@Param("quizId") UUID quizId);
 }

--- a/src/main/java/uk/gegc/quizmaker/repository/attempt/QuestionStatsProjection.java
+++ b/src/main/java/uk/gegc/quizmaker/repository/attempt/QuestionStatsProjection.java
@@ -4,6 +4,8 @@ import java.util.UUID;
 
 public interface QuestionStatsProjection {
     UUID getQuestionId();
+
     long getTimesAsked();
+
     long getTimesCorrect();
 }

--- a/src/main/java/uk/gegc/quizmaker/repository/quiz/QuizRepository.java
+++ b/src/main/java/uk/gegc/quizmaker/repository/quiz/QuizRepository.java
@@ -16,20 +16,20 @@ import java.util.UUID;
 public interface QuizRepository extends JpaRepository<Quiz, UUID> {
 
     @Query("""
-      SELECT q
-      FROM Quiz q
-      LEFT JOIN FETCH q.tags
-      WHERE q.id = :id AND q.isDeleted = false
-    """)
+              SELECT q
+              FROM Quiz q
+              LEFT JOIN FETCH q.tags
+              WHERE q.id = :id AND q.isDeleted = false
+            """)
     Optional<Quiz> findByIdWithTags(@Param("id") UUID id);
 
     @Query("""
-      SELECT q
-      FROM Quiz q
-      LEFT JOIN FETCH q.questions
-      WHERE q.id = :id AND q.isDeleted = false
-    """)
+              SELECT q
+              FROM Quiz q
+              LEFT JOIN FETCH q.questions
+              WHERE q.id = :id AND q.isDeleted = false
+            """)
     Optional<Quiz> findByIdWithQuestions(@Param("id") UUID id);
 
-    Page<Quiz>  findAllByVisibility(Visibility visibility, Pageable pageable);
+    Page<Quiz> findAllByVisibility(Visibility visibility, Pageable pageable);
 }

--- a/src/main/java/uk/gegc/quizmaker/repository/user/UserRepository.java
+++ b/src/main/java/uk/gegc/quizmaker/repository/user/UserRepository.java
@@ -11,8 +11,11 @@ import java.util.UUID;
 public interface UserRepository extends JpaRepository<User, UUID> {
 
     Optional<User> findByUsername(String username);
+
     Optional<User> findByEmail(String email);
+
     boolean existsByUsername(String username);
+
     boolean existsByEmail(String email);
 
 }

--- a/src/main/java/uk/gegc/quizmaker/security/JwtAuthenticationFilter.java
+++ b/src/main/java/uk/gegc/quizmaker/security/JwtAuthenticationFilter.java
@@ -21,9 +21,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-        if(authHeader != null && authHeader.startsWith("Bearer ")){
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
             String token = authHeader.substring(7);
-            if(jwtTokenProvider.validateToken(token)){
+            if (jwtTokenProvider.validateToken(token)) {
                 Authentication authentication = jwtTokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }

--- a/src/main/java/uk/gegc/quizmaker/security/JwtTokenProvider.java
+++ b/src/main/java/uk/gegc/quizmaker/security/JwtTokenProvider.java
@@ -39,12 +39,12 @@ public class JwtTokenProvider {
     private SecretKey key;
 
     @PostConstruct
-    public void init(){
+    public void init() {
         byte[] keyBytes = Decoders.BASE64.decode(base64secret);
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    public String generateAccessToken(Authentication authentication){
+    public String generateAccessToken(Authentication authentication) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + accessTokenValidityInMs);
 
@@ -57,7 +57,7 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public String generateRefreshToken(Authentication authentication){
+    public String generateRefreshToken(Authentication authentication) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + refreshTokenValidityInMs);
 
@@ -70,7 +70,7 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public Authentication getAuthentication(String token){
+    public Authentication getAuthentication(String token) {
         Claims claims = Jwts.parser()
                 .verifyWith(key)
                 .build()
@@ -82,20 +82,20 @@ public class JwtTokenProvider {
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 
-    public boolean validateToken(String token){
-        try{
+    public boolean validateToken(String token) {
+        try {
             Jwts.parser()
                     .verifyWith(key)
                     .build()
                     .parseSignedClaims(token)
                     .getPayload();
             return true;
-        } catch (JwtException | IllegalArgumentException exception){
+        } catch (JwtException | IllegalArgumentException exception) {
             return false;
         }
     }
 
-    public String getUsername(String token){
+    public String getUsername(String token) {
         return Jwts.parser()
                 .verifyWith(key)
                 .build()
@@ -104,7 +104,7 @@ public class JwtTokenProvider {
                 .getSubject();
     }
 
-    public Claims getClaims(String token){
+    public Claims getClaims(String token) {
         return Jwts.parser()
                 .verifyWith(key)
                 .build()

--- a/src/main/java/uk/gegc/quizmaker/service/attempt/AttemptService.java
+++ b/src/main/java/uk/gegc/quizmaker/service/attempt/AttemptService.java
@@ -3,6 +3,7 @@ package uk.gegc.quizmaker.service.attempt;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import uk.gegc.quizmaker.dto.attempt.*;
+import uk.gegc.quizmaker.dto.result.LeaderboardEntryDto;
 import uk.gegc.quizmaker.dto.result.QuizResultSummaryDto;
 import uk.gegc.quizmaker.model.attempt.AttemptMode;
 
@@ -11,11 +12,18 @@ import java.util.UUID;
 
 public interface AttemptService {
     AttemptDto startAttempt(String username, UUID quizId, AttemptMode mode);
+
     Page<AttemptDto> getAttempts(String username, Pageable pageable, UUID quizId, UUID userId);
+
     AttemptDetailsDto getAttemptDetail(String username, UUID attemptId);
+
     AnswerSubmissionDto submitAnswer(String username, UUID attemptId, AnswerSubmissionRequest request);
+
     List<AnswerSubmissionDto> submitBatch(String username, UUID attemptId, BatchAnswerSubmissionRequest request);
+
     AttemptResultDto completeAttempt(String username, UUID attemptId);
+
     QuizResultSummaryDto getQuizResultSummary(UUID quizId);
 
+    List<LeaderboardEntryDto> getQuizLeaderboard(UUID quizId, int top);
 }

--- a/src/main/java/uk/gegc/quizmaker/service/auth/AuthService.java
+++ b/src/main/java/uk/gegc/quizmaker/service/auth/AuthService.java
@@ -10,8 +10,12 @@ import uk.gegc.quizmaker.dto.user.UserDto;
 
 public interface AuthService {
     UserDto register(@Valid RegisterRequest request);
+
     JwtResponse login(LoginRequest loginRequest);
+
     JwtResponse refresh(RefreshRequest refreshRequest);
+
     void logout(String token);
+
     UserDto getCurrentUser(Authentication authentication);
 }

--- a/src/main/java/uk/gegc/quizmaker/service/auth/impl/AuthServiceImpl.java
+++ b/src/main/java/uk/gegc/quizmaker/service/auth/impl/AuthServiceImpl.java
@@ -41,11 +41,11 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public UserDto register(RegisterRequest request) {
 
-        if(userRepository.existsByUsername(request.username())){
+        if (userRepository.existsByUsername(request.username())) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Username already in use");
         }
 
-        if(userRepository.existsByEmail(request.email())){
+        if (userRepository.existsByEmail(request.email())) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Email already in use");
         }
 
@@ -65,7 +65,7 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public JwtResponse login(LoginRequest loginRequest) {
-        try{
+        try {
             Authentication authentication = authManager.authenticate(
                     new UsernamePasswordAuthenticationToken(loginRequest.username(), loginRequest.password())
             );
@@ -78,7 +78,7 @@ public class AuthServiceImpl implements AuthService {
             return new JwtResponse(accessToken, refreshToken, accessExpiresInMs, refreshExpiresInMs);
         } catch (AuthenticationException ex) {
             throw new UnauthorizedException("Invalid username or password");
-        } catch (Exception exception){
+        } catch (Exception exception) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid username or password");
         }
     }
@@ -88,12 +88,12 @@ public class AuthServiceImpl implements AuthService {
 
         String token = refreshRequest.refreshToken();
 
-        if(!jwtTokenProvider.validateToken(token)){
+        if (!jwtTokenProvider.validateToken(token)) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid refresh token");
         }
 
         String type = jwtTokenProvider.getClaims(token).get("type", String.class);
-        if(!"refresh".equals(type)){
+        if (!"refresh".equals(type)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Token is not a refresh token");
         }
 
@@ -114,7 +114,7 @@ public class AuthServiceImpl implements AuthService {
     public UserDto getCurrentUser(Authentication authentication) {
         String username = authentication.getName();
         User user = userRepository.findByUsername(username)
-                .or(()->userRepository.findByEmail(username))
+                .or(() -> userRepository.findByEmail(username))
                 .orElseThrow(() -> new ResourceNotFoundException("User  " + username + " not found"));
         return userMapper.toDto(user);
     }

--- a/src/main/java/uk/gegc/quizmaker/service/question/handler/ComplianceHandler.java
+++ b/src/main/java/uk/gegc/quizmaker/service/question/handler/ComplianceHandler.java
@@ -54,7 +54,7 @@ public class ComplianceHandler extends QuestionHandler {
                 .collect(Collectors.toSet());
 
         boolean isCorrect = selected.equals(correct);
-        Answer ans        = new Answer();
+        Answer ans = new Answer();
         ans.setIsCorrect(isCorrect);
         ans.setScore(isCorrect ? 1.0 : 0.0);
         return ans;

--- a/src/main/java/uk/gegc/quizmaker/service/question/handler/FillGapHandler.java
+++ b/src/main/java/uk/gegc/quizmaker/service/question/handler/FillGapHandler.java
@@ -48,13 +48,13 @@ public class FillGapHandler extends QuestionHandler {
                               Question question,
                               JsonNode content,
                               JsonNode response) {
-        Map<Integer,String> correct = StreamSupport.stream(content.get("gaps").spliterator(), false)
+        Map<Integer, String> correct = StreamSupport.stream(content.get("gaps").spliterator(), false)
                 .collect(Collectors.toMap(
                         gap -> gap.get("id").asInt(),
                         gap -> gap.get("answer").asText().trim().toLowerCase()
                 ));
 
-        Map<Integer,String> given = StreamSupport.stream(response.get("gaps").spliterator(), false)
+        Map<Integer, String> given = StreamSupport.stream(response.get("gaps").spliterator(), false)
                 .collect(Collectors.toMap(
                         gap -> gap.get("id").asInt(),
                         gap -> gap.get("answer").asText().trim().toLowerCase()

--- a/src/main/java/uk/gegc/quizmaker/service/question/handler/OpenQuestionHandler.java
+++ b/src/main/java/uk/gegc/quizmaker/service/question/handler/OpenQuestionHandler.java
@@ -30,7 +30,7 @@ public class OpenQuestionHandler extends QuestionHandler {
                               JsonNode content,
                               JsonNode response) {
         String correct = content.get("answer").asText().trim().toLowerCase();
-        String given   = response.get("answer").asText().trim().toLowerCase();
+        String given = response.get("answer").asText().trim().toLowerCase();
         boolean isCorrect = correct.equals(given);
 
         Answer ans = new Answer();

--- a/src/main/java/uk/gegc/quizmaker/service/question/handler/OrderingHandler.java
+++ b/src/main/java/uk/gegc/quizmaker/service/question/handler/OrderingHandler.java
@@ -51,7 +51,7 @@ public class OrderingHandler extends QuestionHandler {
                 .toList();
 
         boolean isCorrect = correctOrder.equals(userOrder);
-        Answer ans        = new Answer();
+        Answer ans = new Answer();
         ans.setIsCorrect(isCorrect);
         ans.setScore(isCorrect ? 1.0 : 0.0);
         return ans;

--- a/src/main/java/uk/gegc/quizmaker/service/quiz/QuizService.java
+++ b/src/main/java/uk/gegc/quizmaker/service/quiz/QuizService.java
@@ -1,6 +1,5 @@
 package uk.gegc.quizmaker.service.quiz;
 
-import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import uk.gegc.quizmaker.dto.quiz.*;

--- a/src/main/java/uk/gegc/quizmaker/service/quiz/impl/QuizServiceImpl.java
+++ b/src/main/java/uk/gegc/quizmaker/service/quiz/impl/QuizServiceImpl.java
@@ -44,7 +44,7 @@ public class QuizServiceImpl implements QuizService {
     @Override
     public UUID createQuiz(String username, CreateQuizRequest request) {
         User creator = userRepository.findByUsername(username)
-                .or(()->userRepository.findByEmail(username))
+                .or(() -> userRepository.findByEmail(username))
                 .orElseThrow(() -> new ResourceNotFoundException("User " + username + " not found"));
 
         Category category = Optional.ofNullable(request.categoryId())
@@ -202,7 +202,7 @@ public class QuizServiceImpl implements QuizService {
         Quiz quiz = quizRepository.findById(quizId).orElseThrow(() -> new ResourceNotFoundException("Quiz " + quizId + " not found"));
         quiz.setVisibility(visibility);
 
-        return quizMapper.toDto(quizRepository.save(quiz)) ;
+        return quizMapper.toDto(quizRepository.save(quiz));
     }
 
     @Override

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,19 +15,14 @@ logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.springframework.orm.jpa=DEBUG
-
 spring.config.import=optional:classpath:secret.properties
 jwt.access-expiration-ms=43200000
 jwt.refresh-expiration-ms=604800000
-
 # serve the raw OpenAPI JSON under /api/v1/docs
 springdoc.api-docs.path=/api/v1/docs
-
 # serve the Swagger-UI HTML under /api/v1/docs/swagger-ui.html
 springdoc.swagger-ui.path=/api/v1/docs/swagger-ui.html
-
 # point the UI itself at your new JSON location
 springdoc.swagger-ui.url=/api/v1/docs
-
 management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=always

--- a/src/test/java/uk/gegc/quizmaker/controller/AttemptControllerIntegrationTest.java
+++ b/src/test/java/uk/gegc/quizmaker/controller/AttemptControllerIntegrationTest.java
@@ -86,37 +86,6 @@ public class AttemptControllerIntegrationTest {
     @Autowired
     private AttemptRepository attemptRepository;
 
-    @BeforeEach
-    void setUp() throws Exception {
-        quizRepository.deleteAll();
-        categoryRepository.deleteAll();
-
-        User defaultUser = new User();
-        defaultUser.setUsername("defaultUser");
-        defaultUser.setEmail("def@ex.com");
-        defaultUser.setHashedPassword("pw");
-        defaultUser.setActive(true);
-        defaultUser.setDeleted(false);
-        userRepository.save(defaultUser);
-
-        Category cat = new Category();
-        cat.setName("General");
-        categoryRepository.save(cat);
-
-        CreateQuizRequest cq = new CreateQuizRequest(
-                "Integration Quiz","desc",
-                Visibility.PRIVATE, Difficulty.MEDIUM,
-                false, false, 10, 5,
-                cat.getId(),List.of()
-        );
-        String body = objectMapper.writeValueAsString(cq);
-        String resp = mockMvc.perform(post("/api/v1/quizzes")
-                        .contentType(APPLICATION_JSON).content(body))
-                .andExpect(status().isCreated()).andReturn()
-                .getResponse().getContentAsString();
-        quizId = UUID.fromString(objectMapper.readTree(resp).get("quizId").asText());
-    }
-
     /**
      * Parameterized happy‐paths for every QuestionType
      */
@@ -202,6 +171,37 @@ public class AttemptControllerIntegrationTest {
         );
     }
 
+    @BeforeEach
+    void setUp() throws Exception {
+        quizRepository.deleteAll();
+        categoryRepository.deleteAll();
+
+        User defaultUser = new User();
+        defaultUser.setUsername("defaultUser");
+        defaultUser.setEmail("def@ex.com");
+        defaultUser.setHashedPassword("pw");
+        defaultUser.setActive(true);
+        defaultUser.setDeleted(false);
+        userRepository.save(defaultUser);
+
+        Category cat = new Category();
+        cat.setName("General");
+        categoryRepository.save(cat);
+
+        CreateQuizRequest cq = new CreateQuizRequest(
+                "Integration Quiz", "desc",
+                Visibility.PRIVATE, Difficulty.MEDIUM,
+                false, false, 10, 5,
+                cat.getId(), List.of()
+        );
+        String body = objectMapper.writeValueAsString(cq);
+        String resp = mockMvc.perform(post("/api/v1/quizzes")
+                        .contentType(APPLICATION_JSON).content(body))
+                .andExpect(status().isCreated()).andReturn()
+                .getResponse().getContentAsString();
+        quizId = UUID.fromString(objectMapper.readTree(resp).get("quizId").asText());
+    }
+
     @DisplayName("[HAPPY] Parameterized: submit + complete for each QuestionType")
     @ParameterizedTest(name = "[{index}] {0} → correct?={3}")
     @MethodSource("questionScenarios")
@@ -272,7 +272,7 @@ public class AttemptControllerIntegrationTest {
 
     @Test
     @DisplayName("SubmitAnswer with missing response → returns 400 BAD_REQUEST")
-    void submitValidationError() throws Exception{
+    void submitValidationError() throws Exception {
         CreateQuestionRequest createQuestionRequest = new CreateQuestionRequest();
         createQuestionRequest.setType(TRUE_FALSE);
         createQuestionRequest.setDifficulty(Difficulty.MEDIUM);
@@ -282,8 +282,8 @@ public class AttemptControllerIntegrationTest {
         createQuestionRequest.setTagIds(List.of());
         String questionRequestJson = objectMapper.writeValueAsString(createQuestionRequest);
         String questionResponse = mockMvc.perform(post("/api/v1/questions")
-                .contentType(APPLICATION_JSON)
-                .content(questionRequestJson))
+                        .contentType(APPLICATION_JSON)
+                        .content(questionRequestJson))
                 .andReturn().getResponse().getContentAsString();
         UUID questionId = UUID.fromString(objectMapper.readTree(questionResponse).get("questionId").asText());
 
@@ -294,8 +294,8 @@ public class AttemptControllerIntegrationTest {
         String badJson = "{\"questionId\":\"" + questionId + "\"}";
 
         mockMvc.perform(post("/api/v1/attempts/{id}/answers", attemptId)
-                .contentType(APPLICATION_JSON)
-                .content(badJson))
+                        .contentType(APPLICATION_JSON)
+                        .content(badJson))
                 .andExpect(status().isBadRequest());
     }
 
@@ -333,11 +333,11 @@ public class AttemptControllerIntegrationTest {
     void submitAnswer_anonymous_returns401() throws Exception {
         UUID attemptId = UUID.randomUUID();
         String payload = """
-        {
-          "questionId":"%s",
-          "response":{}
-        }
-        """.formatted(UUID.randomUUID());
+                {
+                  "questionId":"%s",
+                  "response":{}
+                }
+                """.formatted(UUID.randomUUID());
         mockMvc.perform(post("/api/v1/attempts/{id}/answers", attemptId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(payload)
@@ -359,15 +359,15 @@ public class AttemptControllerIntegrationTest {
 
         UUID questionId = createDummyQuestion(TRUE_FALSE, "{\"answer\":true}");
         String payload = """
-        {
-          "questionId":"%s",
-          "response":{"answer":true}
-        }
-        """.formatted(questionId);
+                {
+                  "questionId":"%s",
+                  "response":{"answer":true}
+                }
+                """.formatted(questionId);
         mockMvc.perform(post("/api/v1/attempts/{id}/answers", attempt.getId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(payload)
-                .with(user("admin").roles("ADMIN")))
+                        .with(user("admin").roles("ADMIN")))
                 .andExpect(status().isForbidden());
     }
 
@@ -375,7 +375,7 @@ public class AttemptControllerIntegrationTest {
     @DisplayName("POST /api/v1/attempts/{id}/answers after attempt completed → returns 409 CONFLICT")
     void submitAnswer_afterComplete_returns409() throws Exception {
         UUID questionId = createDummyQuestion(TRUE_FALSE, "{\"answer\":true}");
-        UUID attemptId  = startAttempt();
+        UUID attemptId = startAttempt();
 
         postAnswer(attemptId, questionId, "{\"answer\":true}")
                 .andExpect(status().isOk());
@@ -468,26 +468,26 @@ public class AttemptControllerIntegrationTest {
 
     @Test
     @DisplayName("Batch submission in ONE_BY_ONE mode → returns 409 CONFLICT")
-    void batchInOneByOneMode() throws Exception{
+    void batchInOneByOneMode() throws Exception {
         String startJson = "{\"mode\":\"ONE_BY_ONE\"}";
         String start = mockMvc.perform(post("/api/v1/attempts/quizzes/{quizId}", quizId)
-                .contentType(APPLICATION_JSON)
-                .content(startJson))
+                        .contentType(APPLICATION_JSON)
+                        .content(startJson))
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
 
         UUID attemptId = UUID.fromString(objectMapper.readTree(start).get("attemptId").asText());
 
         String batchJson = """
-    {
-      "answers": [
-        {
-          "questionId": "00000000-0000-0000-0000-000000000000",
-          "response": {}
-        }
-      ]
-    }
-    """;
+                {
+                  "answers": [
+                    {
+                      "questionId": "00000000-0000-0000-0000-000000000000",
+                      "response": {}
+                    }
+                  ]
+                }
+                """;
 
         mockMvc.perform(post("/api/v1/attempts/{id}/answers/batch", attemptId)
                         .contentType(APPLICATION_JSON)
@@ -499,7 +499,7 @@ public class AttemptControllerIntegrationTest {
 
     @Test
     @DisplayName("Completing an already completed attempt → returns 409 CONFLICT")
-    void completeTwice() throws Exception{
+    void completeTwice() throws Exception {
 
         String start = mockMvc.perform(post("/api/v1/attempts/quizzes/{quizId}", quizId)).andReturn().getResponse().getContentAsString();
         UUID attemptId = UUID.fromString(objectMapper.readTree(start).get("attemptId").asText());
@@ -528,13 +528,13 @@ public class AttemptControllerIntegrationTest {
 
     @Test
     @DisplayName("GET /api/v1/attempts?quizId={quizId}&userId={userId} → returns filtered attempts by quizId and userId")
-    void filteringByQuizIdAndUserId() throws Exception{
+    void filteringByQuizIdAndUserId() throws Exception {
 
         mockMvc.perform(post("/api/v1/attempts/quizzes/{quizId}", quizId));
         mockMvc.perform(post("/api/v1/attempts/quizzes/{quizId}", quizId));
 
         mockMvc.perform(get("/api/v1/attempts")
-                .param("quizId", quizId.toString()))
+                        .param("quizId", quizId.toString()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalElements", is(2)));
 
@@ -546,7 +546,7 @@ public class AttemptControllerIntegrationTest {
 
     @Test
     @DisplayName("Timed mode attempt timeout → returns 409 CONFLICT")
-    void timedModeTimeout() throws Exception{
+    void timedModeTimeout() throws Exception {
         CreateQuizRequest timedQuiz = new CreateQuizRequest(
                 "Timed",
                 "description",
@@ -562,8 +562,8 @@ public class AttemptControllerIntegrationTest {
 
         String timedJson = objectMapper.writeValueAsString(timedQuiz);
         String timedResponse = mockMvc.perform(post("/api/v1/quizzes")
-                .contentType(APPLICATION_JSON)
-                .content(timedJson))
+                        .contentType(APPLICATION_JSON)
+                        .content(timedJson))
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
 
@@ -581,8 +581,8 @@ public class AttemptControllerIntegrationTest {
                 List.of());
         String questionJson = objectMapper.writeValueAsString(createQuestionRequest);
         String questionResponse = mockMvc.perform(post("/api/v1/questions")
-                .contentType(APPLICATION_JSON)
-                .content(questionJson))
+                        .contentType(APPLICATION_JSON)
+                        .content(questionJson))
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
         UUID questionId = UUID.fromString(objectMapper.readTree(questionResponse).get("questionId").asText());
@@ -592,8 +592,8 @@ public class AttemptControllerIntegrationTest {
 
         String startJson = "{\"mode\":\"TIMED\"}";
         String attemptResponse = mockMvc.perform(post("/api/v1/attempts/quizzes/{quizId}", timedQuizId)
-                .contentType(APPLICATION_JSON)
-                .content(startJson))
+                        .contentType(APPLICATION_JSON)
+                        .content(startJson))
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
 
@@ -611,8 +611,8 @@ public class AttemptControllerIntegrationTest {
         );
 
         mockMvc.perform(post("/api/v1/attempts/{id}/answers", attemptId)
-                .contentType(APPLICATION_JSON)
-                .content(badSubmit))
+                        .contentType(APPLICATION_JSON)
+                        .content(badSubmit))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error", is("Conflict")))
                 .andExpect(jsonPath("$.details[0]", is("Attempt has timed out")));
@@ -620,15 +620,15 @@ public class AttemptControllerIntegrationTest {
 
     @Test
     @DisplayName("Batch submission in ALL_AT_ONCE mode (happy + sad) → succeeds for valid and fails for invalid as expected")
-    void batchSubmissionHappyAndSad() throws Exception{
+    void batchSubmissionHappyAndSad() throws Exception {
 
         UUID question1 = createDummyQuestion(TRUE_FALSE, "{ \"answer\": true }");
         UUID question2 = createDummyQuestion(TRUE_FALSE, "{ \"answer\": false }");
 
         String startJson = "{\"mode\":\"ALL_AT_ONCE\"}";
         String startRequest = mockMvc.perform(post("/api/v1/attempts/quizzes/{quizId}", quizId)
-                .contentType(APPLICATION_JSON)
-                .content(startJson))
+                        .contentType(APPLICATION_JSON)
+                        .content(startJson))
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
         UUID attemptId = UUID.fromString(objectMapper.readTree(startRequest).get("attemptId").asText());
@@ -644,8 +644,8 @@ public class AttemptControllerIntegrationTest {
         String batchJson = objectMapper.writeValueAsString(batchRequest);
 
         mockMvc.perform(post("/api/v1/attempts/{id}/answers/batch", attemptId)
-                .contentType(APPLICATION_JSON)
-                .content(batchJson))
+                        .contentType(APPLICATION_JSON)
+                        .content(batchJson))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(2)))
                 .andExpect(jsonPath("$[0].isCorrect", is(true)))
@@ -653,8 +653,8 @@ public class AttemptControllerIntegrationTest {
 
         String badBatch = "{\"answers\":[{\"questionId\":\"" + question1 + "\"}]}";
         mockMvc.perform(post("/api/v1/attempts/{id}/answers/batch", attemptId)
-                .contentType(APPLICATION_JSON)
-                .content(badBatch))
+                        .contentType(APPLICATION_JSON)
+                        .content(badBatch))
                 .andExpect(status().isBadRequest());
 
 
@@ -662,14 +662,14 @@ public class AttemptControllerIntegrationTest {
 
     @Test
     @DisplayName("GET /api/v1/attempts/{id} when ID not found → returns 404 NOT_FOUND")
-    void getAttemptNotFound() throws Exception{
+    void getAttemptNotFound() throws Exception {
         mockMvc.perform(get("/api/v1/attempts/{id}", UUID.randomUUID()))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     @DisplayName("GET /api/v1/attempts/{id} → returns attempt details")
-    void getAttemptDetails() throws Exception{
+    void getAttemptDetails() throws Exception {
         UUID questionId = createDummyQuestion(TRUE_FALSE, "{ \"answer\": true }");
         UUID attemptId = startAttempt();
 
@@ -684,25 +684,25 @@ public class AttemptControllerIntegrationTest {
 
     @Test
     @DisplayName("Start attempt for non-existent quiz → returns 404 NOT_FOUND")
-    void startAttemptBadQuiz() throws Exception{
+    void startAttemptBadQuiz() throws Exception {
         mockMvc.perform(post("/api/v1/attempts/quizzes/{quizId}", UUID.randomUUID()))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     @DisplayName("GET /api/v1/attempts with negative paging params → returns 400 BAD_REQUEST")
-    void badPagingParams() throws Exception{
+    void badPagingParams() throws Exception {
         mockMvc.perform(get("/api/v1/attempts")
-                .param("page","-1")
-                .param("size","-5"))
+                        .param("page", "-1")
+                        .param("size", "-5"))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
     @DisplayName("SubmitAnswer for question not in quiz → returns 404 NOT_FOUND")
-    void submitWrongQuestion() throws Exception{
+    void submitWrongQuestion() throws Exception {
         UUID otherQuiz = createAnotherQuiz();
-        UUID questionId = createDummyQuestion( TRUE_FALSE, "{ \"answer\": true }", otherQuiz );
+        UUID questionId = createDummyQuestion(TRUE_FALSE, "{ \"answer\": true }", otherQuiz);
         UUID attemptId = startAttempt();
         postAnswer(attemptId, questionId, "{ \"answer\": true }")
                 .andExpect(status().isNotFound());
@@ -710,7 +710,7 @@ public class AttemptControllerIntegrationTest {
 
     @Test
     @DisplayName("Submitting duplicate answer to same question → allowed")
-    void duplicateAnswerBehavior() throws Exception{
+    void duplicateAnswerBehavior() throws Exception {
         UUID questionId = createDummyQuestion(TRUE_FALSE, "{ \"answer\": true }");
         UUID attemptId = startAttempt();
         postAnswer(attemptId, questionId, "{ \"answer\": true }").andExpect(status().isOk());
@@ -726,14 +726,14 @@ public class AttemptControllerIntegrationTest {
                 .andExpect(status().isBadRequest());
     }
 
-    private ResultActions postAnswer(UUID attempt, UUID question, String responseJson) throws Exception{
+    private ResultActions postAnswer(UUID attempt, UUID question, String responseJson) throws Exception {
         var request = new AnswerSubmissionRequest(question, objectMapper.readTree(responseJson));
         return mockMvc.perform(post("/api/v1/attempts/{id}/answers", attempt)
                 .contentType(APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)));
     }
 
-    private UUID startAttempt() throws Exception{
+    private UUID startAttempt() throws Exception {
 
         String startRequest = mockMvc.perform(post("/api/v1/attempts/quizzes/{id}", quizId))
                 .andReturn().getResponse().getContentAsString();
@@ -769,7 +769,7 @@ public class AttemptControllerIntegrationTest {
         return UUID.fromString(objectMapper.readTree(resp).get("quizId").asText());
     }
 
-    private UUID createDummyQuestion(QuestionType type, String contentJson) throws Exception{
+    private UUID createDummyQuestion(QuestionType type, String contentJson) throws Exception {
 
         CreateQuestionRequest createQuestionRequest = new CreateQuestionRequest();
         createQuestionRequest.setType(type);

--- a/src/test/java/uk/gegc/quizmaker/controller/CategoryControllerIntegrationTest.java
+++ b/src/test/java/uk/gegc/quizmaker/controller/CategoryControllerIntegrationTest.java
@@ -40,10 +40,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("Integration Tests CategoryController")
 public class CategoryControllerIntegrationTest {
 
-    @Autowired MockMvc mockMvc;
-    @Autowired ObjectMapper objectMapper;
-    @Autowired CategoryRepository categoryRepository;
-    @Autowired QuizRepository quizRepository;
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    CategoryRepository categoryRepository;
+    @Autowired
+    QuizRepository quizRepository;
 
     @BeforeEach
     void setUp() {
@@ -212,11 +216,11 @@ public class CategoryControllerIntegrationTest {
 
     @Test
     @DisplayName("POST /api/v1/categories without authentication -> returns 403 FORBIDDEN")
-    void createCategory_anonymous_returns403() throws Exception{
+    void createCategory_anonymous_returns403() throws Exception {
         CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("ValidName", "Valid description");
         mockMvc.perform(post("/api/v1/categories")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(createCategoryRequest)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createCategoryRequest)))
                 .andExpect(status().isForbidden());
     }
 

--- a/src/test/java/uk/gegc/quizmaker/controller/QuestionControllerIntegrationTest.java
+++ b/src/test/java/uk/gegc/quizmaker/controller/QuestionControllerIntegrationTest.java
@@ -51,20 +51,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class QuestionControllerIntegrationTest {
 
     @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
     QuestionRepository questionRepository;
-
     @Autowired
     QuizRepository quizRepository;
-
     @Autowired
     CategoryRepository categoryRepository;
-
     @Autowired
     UserRepository userRepository;
-
+    @Autowired
+    private MockMvc mockMvc;
     @Autowired
     private ObjectMapper objectMapper;
 
@@ -260,12 +255,12 @@ public class QuestionControllerIntegrationTest {
     @DisplayName("POST /api/v1/questions missing type returns 400 BAD_REQUEST")
     void createQuestion_missingType_returns400() throws Exception {
         String missingType = """
-            {
-              "difficulty":"EASY",
-              "questionText":"Is this correct?",
-              "content":{"answer":true}
-            }
-            """;
+                {
+                  "difficulty":"EASY",
+                  "questionText":"Is this correct?",
+                  "content":{"answer":true}
+                }
+                """;
 
         mockMvc.perform(post("/api/v1/questions")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -279,12 +274,12 @@ public class QuestionControllerIntegrationTest {
     @DisplayName("POST /api/v1/questions missing difficulty returns 400 BAD_REQUEST")
     void createQuestion_missingDifficulty_returns400() throws Exception {
         String missingDifficulty = """
-            {
-              "type":"TRUE_FALSE",
-              "questionText":"Is this correct?",
-              "content":{"answer":true}
-            }
-            """;
+                {
+                  "type":"TRUE_FALSE",
+                  "questionText":"Is this correct?",
+                  "content":{"answer":true}
+                }
+                """;
 
         mockMvc.perform(post("/api/v1/questions")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -298,12 +293,12 @@ public class QuestionControllerIntegrationTest {
     @DisplayName("POST /api/v1/questions missing questionText returns 400 BAD_REQUEST")
     void createQuestion_missingQuestionText_returns400() throws Exception {
         String missingText = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "content":{"answer":true}
-            }
-            """;
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "content":{"answer":true}
+                }
+                """;
 
         mockMvc.perform(post("/api/v1/questions")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -317,13 +312,13 @@ public class QuestionControllerIntegrationTest {
     @DisplayName("POST /api/v1/questions questionText too short returns 400 BAD_REQUEST")
     void createQuestion_questionTextTooShort_returns400() throws Exception {
         String tooShort = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Hi",
-              "content":{"answer":true}
-            }
-            """;
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"Hi",
+                  "content":{"answer":true}
+                }
+                """;
 
         mockMvc.perform(post("/api/v1/questions")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -338,13 +333,13 @@ public class QuestionControllerIntegrationTest {
     void createQuestion_questionTextTooLong_returns400() throws Exception {
         String longText = "A".repeat(1001);
         String tooLong = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"%s",
-              "content":{"answer":true}
-            }
-            """.formatted(longText);
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"%s",
+                  "content":{"answer":true}
+                }
+                """.formatted(longText);
 
         mockMvc.perform(post("/api/v1/questions")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -358,13 +353,13 @@ public class QuestionControllerIntegrationTest {
     @DisplayName("POST /api/v1/questions content null returns 400 BAD_REQUEST")
     void createQuestion_contentNull_returns400() throws Exception {
         String nullContent = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Is this correct?",
-              "content":null
-            }
-            """;
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"Is this correct?",
+                  "content":null
+                }
+                """;
 
         mockMvc.perform(post("/api/v1/questions")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -379,12 +374,12 @@ public class QuestionControllerIntegrationTest {
     void createQuestion_malformedJson_returns400() throws Exception {
         // missing closing brace
         String badJson = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Is this correct?",
-              "content":{"answer":true}
-        """;
+                    {
+                      "type":"TRUE_FALSE",
+                      "difficulty":"EASY",
+                      "questionText":"Is this correct?",
+                      "content":{"answer":true}
+                """;
 
         mockMvc.perform(post("/api/v1/questions")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -399,14 +394,14 @@ public class QuestionControllerIntegrationTest {
     void createQuestion_hintTooLong_returns400() throws Exception {
         String longHint = "a".repeat(501);
         String json = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Is this correct?",
-              "content":{"answer":true},
-              "hint":"%s"
-            }
-            """.formatted(longHint);
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"Is this correct?",
+                  "content":{"answer":true},
+                  "hint":"%s"
+                }
+                """.formatted(longHint);
 
         mockMvc.perform(post("/api/v1/questions")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -423,14 +418,14 @@ public class QuestionControllerIntegrationTest {
     void createQuestion_explanationTooLong_returns400() throws Exception {
         String longExplanation = "e".repeat(2001);
         String json = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Is this correct?",
-              "content":{"answer":true},
-              "explanation":"%s"
-            }
-            """.formatted(longExplanation);
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"Is this correct?",
+                  "content":{"answer":true},
+                  "explanation":"%s"
+                }
+                """.formatted(longExplanation);
 
         mockMvc.perform(post("/api/v1/questions")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -447,14 +442,14 @@ public class QuestionControllerIntegrationTest {
     void createQuestion_attachmentUrlTooLong_returns400() throws Exception {
         String longUrl = "http://" + "a".repeat(2050) + ".com";
         String json = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Is this correct?",
-              "content":{"answer":true},
-              "attachmentUrl":"%s"
-            }
-            """.formatted(longUrl);
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"Is this correct?",
+                  "content":{"answer":true},
+                  "attachmentUrl":"%s"
+                }
+                """.formatted(longUrl);
 
         mockMvc.perform(post("/api/v1/questions")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -471,14 +466,14 @@ public class QuestionControllerIntegrationTest {
     void createQuestion_unknownQuizId_returns404() throws Exception {
         String badQuizId = UUID.randomUUID().toString();
         String json = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Is this correct?",
-              "content":{"answer":true},
-              "quizIds":["%s"]
-            }
-            """.formatted(badQuizId);
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"Is this correct?",
+                  "content":{"answer":true},
+                  "quizIds":["%s"]
+                }
+                """.formatted(badQuizId);
 
         mockMvc.perform(post("/api/v1/questions")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -495,14 +490,14 @@ public class QuestionControllerIntegrationTest {
     void createQuestion_unknownTagId_returns404() throws Exception {
         String badTagId = UUID.randomUUID().toString();
         String json = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Is this correct?",
-              "content":{"answer":true},
-              "tagIds":["%s"]
-            }
-            """.formatted(badTagId);
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"Is this correct?",
+                  "content":{"answer":true},
+                  "tagIds":["%s"]
+                }
+                """.formatted(badTagId);
 
         mockMvc.perform(post("/api/v1/questions")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -655,13 +650,13 @@ public class QuestionControllerIntegrationTest {
     @DisplayName("GET /api/v1/questions/{id} existing ID as anonymous returns 200 OK with QuestionDto")
     void getQuestion_existingId_anonymousReturns200() throws Exception {
         String payload = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Fetch me!",
-              "content":{"answer":true}
-            }
-            """;
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"Fetch me!",
+                  "content":{"answer":true}
+                }
+                """;
 
         String response = mockMvc.perform(post("/api/v1/questions")
                         .with(user("admin").roles("ADMIN"))
@@ -697,13 +692,13 @@ public class QuestionControllerIntegrationTest {
     @DisplayName("PATCH /api/v1/questions/{id} with all fields returns 200 OK with updated JSON")
     void updateQuestion_allFields_adminReturns200() throws Exception {
         String createJson = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Original?",
-              "content":{"answer":true}
-            }
-            """;
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"Original?",
+                  "content":{"answer":true}
+                }
+                """;
         String createResp = mockMvc.perform(post("/api/v1/questions")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(createJson))
@@ -712,18 +707,18 @@ public class QuestionControllerIntegrationTest {
         UUID qid = UUID.fromString(objectMapper.readTree(createResp).get("questionId").asText());
 
         String updateJson = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"HARD",
-              "questionText":"Updated?",
-              "content":{"answer":false},
-              "hint":"New hint",
-              "explanation":"New explanation",
-              "attachmentUrl":"http://example.com/img.png",
-              "quizIds":[],
-              "tagIds":[]
-            }
-            """;
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"HARD",
+                  "questionText":"Updated?",
+                  "content":{"answer":false},
+                  "hint":"New hint",
+                  "explanation":"New explanation",
+                  "attachmentUrl":"http://example.com/img.png",
+                  "quizIds":[],
+                  "tagIds":[]
+                }
+                """;
         mockMvc.perform(patch("/api/v1/questions/{id}", qid)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(updateJson))
@@ -740,13 +735,13 @@ public class QuestionControllerIntegrationTest {
     @DisplayName("PATCH /api/v1/questions/{id} with only required fields returns 200 OK")
     void updateQuestion_requiredFields_adminReturns200() throws Exception {
         String createJson = """
-            {
-              "type":"MCQ_SINGLE",
-              "difficulty":"MEDIUM",
-              "questionText":"Pick one",
-              "content":{"options":[{"text":"A","correct":false},{"text":"B","correct":true}]}
-            }
-            """;
+                {
+                  "type":"MCQ_SINGLE",
+                  "difficulty":"MEDIUM",
+                  "questionText":"Pick one",
+                  "content":{"options":[{"text":"A","correct":false},{"text":"B","correct":true}]}
+                }
+                """;
         String createResp = mockMvc.perform(post("/api/v1/questions")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(createJson))
@@ -755,13 +750,13 @@ public class QuestionControllerIntegrationTest {
         UUID qid = UUID.fromString(objectMapper.readTree(createResp).get("questionId").asText());
 
         String reqJson = """
-            {
-              "type":"MCQ_SINGLE",
-              "difficulty":"MEDIUM",
-              "questionText":"Pick B",
-              "content":{"options":[{"text":"A","correct":false},{"text":"B","correct":true}]}
-            }
-            """;
+                {
+                  "type":"MCQ_SINGLE",
+                  "difficulty":"MEDIUM",
+                  "questionText":"Pick B",
+                  "content":{"options":[{"text":"A","correct":false},{"text":"B","correct":true}]}
+                }
+                """;
         mockMvc.perform(patch("/api/v1/questions/{id}", qid)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(reqJson))
@@ -777,13 +772,13 @@ public class QuestionControllerIntegrationTest {
     void updateQuestion_anonymousReturns401() throws Exception {
         UUID randomId = UUID.randomUUID();
         String body = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Should fail",
-              "content":{"answer":true}
-            }
-            """;
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"Should fail",
+                  "content":{"answer":true}
+                }
+                """;
         mockMvc.perform(patch("/api/v1/questions/{id}", randomId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
@@ -795,13 +790,13 @@ public class QuestionControllerIntegrationTest {
     @DisplayName("PATCH /api/v1/questions/{id} with USER role returns 403 FORBIDDEN")
     void updateQuestion_userRoleReturns403() throws Exception {
         String createJson = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Original?",
-              "content":{"answer":true}
-            }
-            """;
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"Original?",
+                  "content":{"answer":true}
+                }
+                """;
         String resp = mockMvc.perform(post("/api/v1/questions")
                         .with(user("admin").roles("ADMIN"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -811,13 +806,13 @@ public class QuestionControllerIntegrationTest {
         UUID qid = UUID.fromString(objectMapper.readTree(resp).get("questionId").asText());
 
         String updateJson = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"HARD",
-              "questionText":"Should not work",
-              "content":{"answer":false}
-            }
-            """;
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"HARD",
+                  "questionText":"Should not work",
+                  "content":{"answer":false}
+                }
+                """;
 
         mockMvc.perform(patch("/api/v1/questions/{id}", qid)
                         .with(user("bob").roles("USER"))
@@ -832,13 +827,13 @@ public class QuestionControllerIntegrationTest {
     void updateQuestion_nonexistentIdReturns404() throws Exception {
         UUID missing = UUID.randomUUID();
         String body = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Doesn't matter",
-              "content":{"answer":true}
-            }
-            """;
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"Doesn't matter",
+                  "content":{"answer":true}
+                }
+                """;
 
         mockMvc.perform(patch("/api/v1/questions/{id}", missing)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -853,13 +848,13 @@ public class QuestionControllerIntegrationTest {
     @DisplayName("PATCH /api/v1/questions/{id} invalid body returns 400 BAD_REQUEST")
     void updateQuestion_invalidPayloadReturns400(String name, String jsonPayload) throws Exception {
         String create = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Foo?",
-              "content":{"answer":true}
-            }
-            """;
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"Foo?",
+                  "content":{"answer":true}
+                }
+                """;
         String resp = mockMvc.perform(post("/api/v1/questions")
                         .with(user("admin").roles("ADMIN"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -879,13 +874,13 @@ public class QuestionControllerIntegrationTest {
     @DisplayName("PATCH /api/v1/questions/{id} unknown quizIds returns 404 NOT_FOUND")
     void updateQuestion_unknownQuizIdsReturns404() throws Exception {
         String create = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Question?",
-              "content":{"answer":true}
-            }
-            """;
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"Question?",
+                  "content":{"answer":true}
+                }
+                """;
         String resp = mockMvc.perform(post("/api/v1/questions")
                         .with(user("admin").roles("ADMIN"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -896,14 +891,14 @@ public class QuestionControllerIntegrationTest {
 
         UUID badQuiz = UUID.randomUUID();
         String update = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"With bad quiz",
-              "content":{"answer":true},
-              "quizIds":["%s"]
-            }
-            """.formatted(badQuiz);
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"With bad quiz",
+                  "content":{"answer":true},
+                  "quizIds":["%s"]
+                }
+                """.formatted(badQuiz);
 
         mockMvc.perform(patch("/api/v1/questions/{id}", qid)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -917,13 +912,13 @@ public class QuestionControllerIntegrationTest {
     @DisplayName("PATCH /api/v1/questions/{id} unknown tagIds returns 404 NOT_FOUND")
     void updateQuestion_unknownTagIdsReturns404() throws Exception {
         String create = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Question?",
-              "content":{"answer":true}
-            }
-            """;
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"Question?",
+                  "content":{"answer":true}
+                }
+                """;
         String resp = mockMvc.perform(post("/api/v1/questions")
                         .with(user("admin").roles("ADMIN"))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -934,14 +929,14 @@ public class QuestionControllerIntegrationTest {
 
         UUID badTag = UUID.randomUUID();
         String update = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"With bad tag",
-              "content":{"answer":true},
-              "tagIds":["%s"]
-            }
-            """.formatted(badTag);
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"With bad tag",
+                  "content":{"answer":true},
+                  "tagIds":["%s"]
+                }
+                """.formatted(badTag);
 
         mockMvc.perform(patch("/api/v1/questions/{id}", qid)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -995,13 +990,13 @@ public class QuestionControllerIntegrationTest {
     @DisplayName("DELETE /api/v1/questions/{id} (ADMIN) existing → 204 and subsequent GET → 404")
     void deleteQuestion_existingId_adminReturns204ThenGet404() throws Exception {
         String createJson = """
-            {
-              "type":"TRUE_FALSE",
-              "difficulty":"EASY",
-              "questionText":"Delete me?",
-              "content":{"answer":true}
-            }
-            """;
+                {
+                  "type":"TRUE_FALSE",
+                  "difficulty":"EASY",
+                  "questionText":"Delete me?",
+                  "content":{"answer":true}
+                }
+                """;
         String resp = mockMvc.perform(post("/api/v1/questions")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(createJson))

--- a/src/test/java/uk/gegc/quizmaker/controller/QuizControllerIntegrationTest.java
+++ b/src/test/java/uk/gegc/quizmaker/controller/QuizControllerIntegrationTest.java
@@ -20,6 +20,9 @@ import uk.gegc.quizmaker.dto.question.CreateQuestionRequest;
 import uk.gegc.quizmaker.dto.quiz.BulkQuizUpdateRequest;
 import uk.gegc.quizmaker.dto.quiz.CreateQuizRequest;
 import uk.gegc.quizmaker.dto.quiz.UpdateQuizRequest;
+import uk.gegc.quizmaker.model.attempt.Attempt;
+import uk.gegc.quizmaker.model.attempt.AttemptMode;
+import uk.gegc.quizmaker.model.attempt.AttemptStatus;
 import uk.gegc.quizmaker.model.category.Category;
 import uk.gegc.quizmaker.model.question.Difficulty;
 import uk.gegc.quizmaker.model.question.Question;
@@ -59,13 +62,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("Integration Tests QuizController")
 class QuizControllerIntegrationTest {
 
-    @Autowired MockMvc mockMvc;
-    @Autowired ObjectMapper objectMapper;
-    @Autowired UserRepository userRepository;
-    @Autowired CategoryRepository categoryRepository;
-    @Autowired TagRepository tagRepository;
-    @Autowired QuestionRepository questionRepository;
-    @Autowired QuizRepository quizRepository;
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    CategoryRepository categoryRepository;
+    @Autowired
+    TagRepository tagRepository;
+    @Autowired
+    QuestionRepository questionRepository;
+    @Autowired
+    QuizRepository quizRepository;
     @Autowired
     AttemptRepository attemptRepository;
     @Autowired
@@ -206,15 +216,15 @@ class QuizControllerIntegrationTest {
     @DisplayName("POST /api/v1/quizzes with only required fields -> returns 201 CREATED")
     void createQuiz_requiredFields_adminReturns201() throws Exception {
         String json = """
-        {
-          "title":"Quick Quiz",
-          "estimatedTime":10,
-          "timerDuration":5,
-          "categoryId":"%s",
-          "isRepetitionEnabled":false,
-          "timerEnabled":false
-        }
-        """.formatted(categoryId);
+                {
+                  "title":"Quick Quiz",
+                  "estimatedTime":10,
+                  "timerDuration":5,
+                  "categoryId":"%s",
+                  "isRepetitionEnabled":false,
+                  "timerEnabled":false
+                }
+                """.formatted(categoryId);
 
         mockMvc.perform(post("/api/v1/quizzes")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -227,14 +237,14 @@ class QuizControllerIntegrationTest {
     @DisplayName("POST /api/v1/quizzes missing title -> returns 400 BAD_REQUEST")
     void createQuiz_missingTitle_returns400() throws Exception {
         String json = """
-        {
-          "estimatedTime":10,
-          "timerDuration":5,
-          "categoryId":"%s",
-          "isRepetitionEnabled":false,
-          "timerEnabled":false
-        }
-        """.formatted(categoryId);
+                {
+                  "estimatedTime":10,
+                  "timerDuration":5,
+                  "categoryId":"%s",
+                  "isRepetitionEnabled":false,
+                  "timerEnabled":false
+                }
+                """.formatted(categoryId);
 
         mockMvc.perform(post("/api/v1/quizzes")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -247,15 +257,15 @@ class QuizControllerIntegrationTest {
     @DisplayName("POST /api/v1/quizzes title too short returns 400 BAD_REQUEST")
     void createQuiz_titleTooShort_returns400() throws Exception {
         String json = """
-        {
-          "title":"ab",
-          "estimatedTime":10,
-          "timerDuration":5,
-          "categoryId":"%s",
-          "isRepetitionEnabled":false,
-          "timerEnabled":false
-        }
-        """.formatted(categoryId);
+                {
+                  "title":"ab",
+                  "estimatedTime":10,
+                  "timerDuration":5,
+                  "categoryId":"%s",
+                  "isRepetitionEnabled":false,
+                  "timerEnabled":false
+                }
+                """.formatted(categoryId);
 
         mockMvc.perform(post("/api/v1/quizzes")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -269,15 +279,15 @@ class QuizControllerIntegrationTest {
     void createQuiz_titleTooLong_returns400() throws Exception {
         String longTitle = "x".repeat(101);
         String json = """
-        {
-          "title":"%s",
-          "estimatedTime":10,
-          "timerDuration":5,
-          "categoryId":"%s",
-          "isRepetitionEnabled":false,
-          "timerEnabled":false
-        }
-        """.formatted(longTitle, categoryId);
+                {
+                  "title":"%s",
+                  "estimatedTime":10,
+                  "timerDuration":5,
+                  "categoryId":"%s",
+                  "isRepetitionEnabled":false,
+                  "timerEnabled":false
+                }
+                """.formatted(longTitle, categoryId);
 
         mockMvc.perform(post("/api/v1/quizzes")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -291,16 +301,16 @@ class QuizControllerIntegrationTest {
     void createQuiz_descriptionTooLong_returns400() throws Exception {
         String longDesc = "d".repeat(1001);
         String json = """
-        {
-          "title":"Valid Quiz",
-          "description":"%s",
-          "estimatedTime":10,
-          "timerDuration":5,
-          "categoryId":"%s",
-          "isRepetitionEnabled":false,
-          "timerEnabled":false
-        }
-        """.formatted(longDesc, categoryId);
+                {
+                  "title":"Valid Quiz",
+                  "description":"%s",
+                  "estimatedTime":10,
+                  "timerDuration":5,
+                  "categoryId":"%s",
+                  "isRepetitionEnabled":false,
+                  "timerEnabled":false
+                }
+                """.formatted(longDesc, categoryId);
 
         mockMvc.perform(post("/api/v1/quizzes")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -315,15 +325,15 @@ class QuizControllerIntegrationTest {
     @DisplayName("POST /api/v1/quizzes with estimatedTime < 1 -> returns 400 BAD_REQUEST")
     void createQuiz_estimatedTimeTooLow_returns400() throws Exception {
         String json = """
-        {
-          "title":"Valid Quiz",
-          "estimatedTime":0,
-          "timerDuration":5,
-          "categoryId":"%s",
-          "isRepetitionEnabled":false,
-          "timerEnabled":false
-        }
-        """.formatted(categoryId);
+                {
+                  "title":"Valid Quiz",
+                  "estimatedTime":0,
+                  "timerDuration":5,
+                  "categoryId":"%s",
+                  "isRepetitionEnabled":false,
+                  "timerEnabled":false
+                }
+                """.formatted(categoryId);
 
         mockMvc.perform(post("/api/v1/quizzes")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -338,15 +348,15 @@ class QuizControllerIntegrationTest {
     @DisplayName("POST /api/v1/quizzes with estimatedTime > 180 -> returns 400 BAD_REQUEST")
     void createQuiz_estimatedTimeTooHigh_returns400() throws Exception {
         String json = """
-        {
-          "title":"Valid Quiz",
-          "estimatedTime":181,
-          "timerDuration":5,
-          "categoryId":"%s",
-          "isRepetitionEnabled":false,
-          "timerEnabled":false
-        }
-        """.formatted(categoryId);
+                {
+                  "title":"Valid Quiz",
+                  "estimatedTime":181,
+                  "timerDuration":5,
+                  "categoryId":"%s",
+                  "isRepetitionEnabled":false,
+                  "timerEnabled":false
+                }
+                """.formatted(categoryId);
 
         mockMvc.perform(post("/api/v1/quizzes")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -361,15 +371,15 @@ class QuizControllerIntegrationTest {
     @DisplayName("POST /api/v1/quizzes with timerDuration < 1 ->  returns 400 BAD_REQUEST")
     void createQuiz_timerDurationTooLow_returns400() throws Exception {
         String json = """
-        {
-          "title":"Valid Quiz",
-          "estimatedTime":10,
-          "timerDuration":0,
-          "categoryId":"%s",
-          "isRepetitionEnabled":false,
-          "timerEnabled":false
-        }
-        """.formatted(categoryId);
+                {
+                  "title":"Valid Quiz",
+                  "estimatedTime":10,
+                  "timerDuration":0,
+                  "categoryId":"%s",
+                  "isRepetitionEnabled":false,
+                  "timerEnabled":false
+                }
+                """.formatted(categoryId);
 
         mockMvc.perform(post("/api/v1/quizzes")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -384,15 +394,15 @@ class QuizControllerIntegrationTest {
     @DisplayName("POST /api/v1/quizzes with timerDuration > 180 -> returns 400 BAD_REQUEST")
     void createQuiz_timerDurationTooHigh_returns400() throws Exception {
         String json = """
-        {
-          "title":"Valid Quiz",
-          "estimatedTime":10,
-          "timerDuration":181,
-          "categoryId":"%s",
-          "isRepetitionEnabled":false,
-          "timerEnabled":false
-        }
-        """.formatted(categoryId);
+                {
+                  "title":"Valid Quiz",
+                  "estimatedTime":10,
+                  "timerDuration":181,
+                  "categoryId":"%s",
+                  "isRepetitionEnabled":false,
+                  "timerEnabled":false
+                }
+                """.formatted(categoryId);
 
         mockMvc.perform(post("/api/v1/quizzes")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -408,16 +418,16 @@ class QuizControllerIntegrationTest {
     void createQuiz_unknownTagId_returns404() throws Exception {
         UUID badTag = UUID.randomUUID();
         String json = """
-        {
-          "title":"Valid Quiz",
-          "estimatedTime":10,
-          "timerDuration":5,
-          "categoryId":"%s",
-          "tagIds":["%s"],
-          "isRepetitionEnabled":false,
-          "timerEnabled":false
-        }
-        """.formatted(categoryId, badTag);
+                {
+                  "title":"Valid Quiz",
+                  "estimatedTime":10,
+                  "timerDuration":5,
+                  "categoryId":"%s",
+                  "tagIds":["%s"],
+                  "isRepetitionEnabled":false,
+                  "timerEnabled":false
+                }
+                """.formatted(categoryId, badTag);
 
         mockMvc.perform(post("/api/v1/quizzes")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -432,15 +442,15 @@ class QuizControllerIntegrationTest {
     @DisplayName("POST /api/v1/quizzes anonymous -> returns 401 UNAUTHORIZED")
     void createQuiz_anonymous_returns401() throws Exception {
         String json = """
-        {
-          "title":"Quiz",
-          "estimatedTime":10,
-          "timerDuration":5,
-          "categoryId":"%s",
-          "isRepetitionEnabled":false,
-          "timerEnabled":false
-        }
-        """.formatted(categoryId);
+                {
+                  "title":"Quiz",
+                  "estimatedTime":10,
+                  "timerDuration":5,
+                  "categoryId":"%s",
+                  "isRepetitionEnabled":false,
+                  "timerEnabled":false
+                }
+                """.formatted(categoryId);
 
         mockMvc.perform(post("/api/v1/quizzes")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -498,12 +508,13 @@ class QuizControllerIntegrationTest {
                 .andExpect(jsonPath("$.totalElements", is(0)))
                 .andExpect(jsonPath("$.size", is(5)))
                 .andExpect(jsonPath("$.number", is(0)))
-                .andExpect(jsonPath("$.content", hasSize(0)));;
+                .andExpect(jsonPath("$.content", hasSize(0)));
+        ;
     }
 
     @Test
     @DisplayName("GET /api/v1/quizzes/{id} with non existing id -> returns 404 NOT FOUND")
-    void getNonexistingQuiz_returns404() throws Exception{
+    void getNonexistingQuiz_returns404() throws Exception {
         UUID dummyId = UUID.randomUUID();
 
         mockMvc.perform(get("/api/v1/quizzes/{id}", dummyId))
@@ -575,12 +586,12 @@ class QuizControllerIntegrationTest {
         UUID quizId = UUID.fromString(objectMapper.readTree(body).get("quizId").asText());
 
         String partialJson = """
-        {
-          "title":"Updated Title",
-          "estimatedTime":15,
-          "timerDuration":7
-        }
-        """;
+                {
+                  "title":"Updated Title",
+                  "estimatedTime":15,
+                  "timerDuration":7
+                }
+                """;
         mockMvc.perform(patch("/api/v1/quizzes/{id}", quizId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(partialJson))
@@ -602,8 +613,8 @@ class QuizControllerIntegrationTest {
     void updateQuiz_titleTooShort_returns400() throws Exception {
         UUID id = createSampleQuiz();
         String json = """
-        { "title":"ab" }
-        """;
+                { "title":"ab" }
+                """;
         mockMvc.perform(patch("/api/v1/quizzes/{id}", id)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))
@@ -617,8 +628,8 @@ class QuizControllerIntegrationTest {
         UUID id = createSampleQuiz();
         String longTitle = "x".repeat(101);
         String json = """
-        { "title":"%s" }
-        """.formatted(longTitle);
+                { "title":"%s" }
+                """.formatted(longTitle);
         mockMvc.perform(patch("/api/v1/quizzes/{id}", id)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))
@@ -632,8 +643,8 @@ class QuizControllerIntegrationTest {
         UUID id = createSampleQuiz();
         String longDesc = "d".repeat(1001);
         String json = """
-        { "description":"%s" }
-        """.formatted(longDesc);
+                { "description":"%s" }
+                """.formatted(longDesc);
         mockMvc.perform(patch("/api/v1/quizzes/{id}", id)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))
@@ -646,8 +657,8 @@ class QuizControllerIntegrationTest {
     void updateQuiz_estimatedTimeTooLow_returns400() throws Exception {
         UUID quizId = createSampleQuiz();
         String json = """
-        { "estimatedTime": 0 }
-        """;
+                { "estimatedTime": 0 }
+                """;
         mockMvc.perform(patch("/api/v1/quizzes/{id}", quizId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))
@@ -660,8 +671,8 @@ class QuizControllerIntegrationTest {
     void updateQuiz_estimatedTimeTooHigh_returns400() throws Exception {
         UUID quizId = createSampleQuiz();
         String json = """
-        { "estimatedTime": 181 }
-        """;
+                { "estimatedTime": 181 }
+                """;
         mockMvc.perform(patch("/api/v1/quizzes/{id}", quizId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))
@@ -674,8 +685,8 @@ class QuizControllerIntegrationTest {
     void updateQuiz_timerDurationTooLow_returns400() throws Exception {
         UUID quizId = createSampleQuiz();
         String json = """
-        { "timerDuration": 0 }
-        """;
+                { "timerDuration": 0 }
+                """;
         mockMvc.perform(patch("/api/v1/quizzes/{id}", quizId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))
@@ -688,8 +699,8 @@ class QuizControllerIntegrationTest {
     void updateQuiz_timerDurationTooHigh_returns400() throws Exception {
         UUID quizId = createSampleQuiz();
         String json = """
-        { "timerDuration": 181 }
-        """;
+                { "timerDuration": 181 }
+                """;
         mockMvc.perform(patch("/api/v1/quizzes/{id}", quizId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))
@@ -702,8 +713,8 @@ class QuizControllerIntegrationTest {
     void updateQuiz_nonexistentId_returns404() throws Exception {
         UUID missing = UUID.randomUUID();
         String json = """
-        { "title":"Valid Title" }
-        """;
+                { "title":"Valid Title" }
+                """;
         mockMvc.perform(patch("/api/v1/quizzes/{id}", missing)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))
@@ -717,8 +728,8 @@ class QuizControllerIntegrationTest {
         UUID quizId = createSampleQuiz();
         UUID badTag = UUID.randomUUID();
         String json = """
-        { "tagIds":["%s"] }
-        """.formatted(badTag);
+                { "tagIds":["%s"] }
+                """.formatted(badTag);
         mockMvc.perform(patch("/api/v1/quizzes/{id}", quizId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))
@@ -732,8 +743,8 @@ class QuizControllerIntegrationTest {
         UUID quizId = createSampleQuiz();
         UUID badCat = UUID.randomUUID();
         String json = """
-        { "categoryId":"%s" }
-        """.formatted(badCat);
+                { "categoryId":"%s" }
+                """.formatted(badCat);
         mockMvc.perform(patch("/api/v1/quizzes/{id}", quizId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))
@@ -848,7 +859,7 @@ class QuizControllerIntegrationTest {
         String quizBody = mockMvc.perform(post("/api/v1/quizzes")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
-                                new CreateQuizRequest("ResultsQuiz","desc", null, null, false, false, 5, 2, categoryId, List.of())
+                                new CreateQuizRequest("ResultsQuiz", "desc", null, null, false, false, 5, 2, categoryId, List.of())
                         )))
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
@@ -948,8 +959,8 @@ class QuizControllerIntegrationTest {
         UUID quizId = createSampleQuiz();
 
         String body = """
-        { "isPublic": true }
-        """;
+                { "isPublic": true }
+                """;
 
         mockMvc.perform(patch("/api/v1/quizzes/{id}/visibility", quizId)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -964,8 +975,8 @@ class QuizControllerIntegrationTest {
     void changeVisibility_nonexistentQuiz_returns404() throws Exception {
         UUID missing = UUID.randomUUID();
         String body = """
-        { "isPublic": false }
-        """;
+                { "isPublic": false }
+                """;
 
         mockMvc.perform(patch("/api/v1/quizzes/{id}/visibility", missing)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -1181,6 +1192,158 @@ class QuizControllerIntegrationTest {
         assertEquals(Difficulty.HARD, quizRepository.findById(valid).get().getDifficulty());
     }
 
+    @Test
+    @DisplayName("GET /api/v1/quizzes/{quizId}/leaderboard with participants -> returns ordered list")
+    void getQuizLeaderboard_basic() throws Exception {
+        UUID quizId = createSampleQuiz();
+
+        User alice = new User();
+        alice.setUsername("alice");
+        alice.setEmail("alice@example.com");
+        alice.setHashedPassword("pw");
+        alice.setActive(true);
+        alice.setDeleted(false);
+        userRepository.save(alice);
+
+        User bob = new User();
+        bob.setUsername("bob");
+        bob.setEmail("bob@example.com");
+        bob.setHashedPassword("pw");
+        bob.setActive(true);
+        bob.setDeleted(false);
+        userRepository.save(bob);
+
+        User carol = new User();
+        carol.setUsername("carol");
+        carol.setEmail("carol@example.com");
+        carol.setHashedPassword("pw");
+        carol.setActive(true);
+        carol.setDeleted(false);
+        userRepository.save(carol);
+
+        var quiz = quizRepository.findById(quizId).get();
+
+        Attempt a1 = new Attempt();
+        a1.setUser(alice);
+        a1.setQuiz(quiz);
+        a1.setMode(AttemptMode.ALL_AT_ONCE);
+        a1.setStatus(AttemptStatus.COMPLETED);
+        a1.setTotalScore(95.0);
+
+        Attempt a2 = new Attempt();
+        a2.setUser(bob);
+        a2.setQuiz(quiz);
+        a2.setMode(AttemptMode.ALL_AT_ONCE);
+        a2.setStatus(AttemptStatus.COMPLETED);
+        a2.setTotalScore(85.0);
+
+        Attempt a3 = new Attempt();
+        a3.setUser(carol);
+        a3.setQuiz(quiz);
+        a3.setMode(AttemptMode.ALL_AT_ONCE);
+        a3.setStatus(AttemptStatus.COMPLETED);
+        a3.setTotalScore(75.0);
+
+        attemptRepository.save(a1);
+        attemptRepository.save(a2);
+        attemptRepository.save(a3);
+
+        mockMvc.perform(get("/api/v1/quizzes/{quizId}/leaderboard", quizId)
+                        .param("top", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].userId", is(alice.getId().toString())))
+                .andExpect(jsonPath("$[0].bestScore", is(95.0)))
+                .andExpect(jsonPath("$[1].userId", is(bob.getId().toString())));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/quizzes/{quizId}/leaderboard -> handles ties and short list")
+    void getQuizLeaderboard_tiesAndShortList() throws Exception {
+        UUID quizId = createSampleQuiz();
+
+        User u1 = new User();
+        u1.setUsername("u1");
+        u1.setEmail("u1@example.com");
+        u1.setHashedPassword("pw");
+        u1.setActive(true);
+        u1.setDeleted(false);
+        userRepository.save(u1);
+
+        User u2 = new User();
+        u2.setUsername("u2");
+        u2.setEmail("u2@example.com");
+        u2.setHashedPassword("pw");
+        u2.setActive(true);
+        u2.setDeleted(false);
+        userRepository.save(u2);
+
+        var quiz = quizRepository.findById(quizId).get();
+
+        Attempt t1 = new Attempt();
+        t1.setUser(u1);
+        t1.setQuiz(quiz);
+        t1.setMode(AttemptMode.ALL_AT_ONCE);
+        t1.setStatus(AttemptStatus.COMPLETED);
+        t1.setTotalScore(50.0);
+
+        Attempt t2 = new Attempt();
+        t2.setUser(u2);
+        t2.setQuiz(quiz);
+        t2.setMode(AttemptMode.ALL_AT_ONCE);
+        t2.setStatus(AttemptStatus.COMPLETED);
+        t2.setTotalScore(50.0);
+
+        attemptRepository.save(t1);
+        attemptRepository.save(t2);
+
+        mockMvc.perform(get("/api/v1/quizzes/{quizId}/leaderboard", quizId)
+                        .param("top", "5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[*].bestScore", everyItem(is(50.0))))
+                .andExpect(jsonPath("$[*].userId", containsInAnyOrder(
+                        u1.getId().toString(), u2.getId().toString())));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/quizzes/{quizId}/leaderboard when no attempts -> returns empty list")
+    void getQuizLeaderboard_noAttempts_returnsEmpty() throws Exception {
+        UUID quizId = createSampleQuiz();
+        mockMvc.perform(get("/api/v1/quizzes/{quizId}/leaderboard", quizId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/quizzes/{quizId}/leaderboard with top<=0 returns empty list")
+    void getQuizLeaderboard_negativeTop_returnsEmpty() throws Exception {
+        UUID quizId = createSampleQuiz();
+        User def = userRepository.findByUsername("defaultUser").get();
+        var quiz = quizRepository.findById(quizId).get();
+
+        Attempt att = new Attempt();
+        att.setUser(def);
+        att.setQuiz(quiz);
+        att.setMode(AttemptMode.ALL_AT_ONCE);
+        att.setStatus(AttemptStatus.COMPLETED);
+        att.setTotalScore(42.0);
+        attemptRepository.save(att);
+
+        mockMvc.perform(get("/api/v1/quizzes/{quizId}/leaderboard", quizId)
+                        .param("top", "0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/quizzes/{quizId}/leaderboard with non-existent quiz -> returns 404")
+    void getQuizLeaderboard_nonexistentQuiz_returns404() throws Exception {
+        UUID missing = UUID.randomUUID();
+        mockMvc.perform(get("/api/v1/quizzes/{quizId}/leaderboard", missing))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.details[0]", containsString("Quiz " + missing + " not found")));
+    }
 
     private UUID createSampleQuiz() throws Exception {
         CreateQuizRequest req = new CreateQuizRequest(

--- a/src/test/java/uk/gegc/quizmaker/controller/TagControllerIntegrationTest.java
+++ b/src/test/java/uk/gegc/quizmaker/controller/TagControllerIntegrationTest.java
@@ -147,7 +147,7 @@ public class TagControllerIntegrationTest {
     @DisplayName("POST /api/v1/tags with too long name → returns 400 BAD_REQUEST")
     @WithMockUser(roles = "ADMIN")
     void create_TooLongName_ShouldReturn400() throws Exception {
-        String longName = "x" .repeat(101);
+        String longName = "x".repeat(101);
         CreateTagRequest request = new CreateTagRequest(longName, "description");
         mockMvc.perform(post("/api/v1/tags")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -160,7 +160,7 @@ public class TagControllerIntegrationTest {
     @DisplayName("POST /api/v1/tags with too long description → returns 400 BAD_REQUEST")
     @WithMockUser(roles = "ADMIN")
     void create_TooLongDescription_ShouldReturn400() throws Exception {
-        String longDesc = "d" .repeat(1001);
+        String longDesc = "d".repeat(1001);
         CreateTagRequest req = new CreateTagRequest("ValidName", longDesc);
         mockMvc.perform(post("/api/v1/tags")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -206,7 +206,7 @@ public class TagControllerIntegrationTest {
         Tag tag = new Tag();
         tag.setName("OK");
         tagRepository.save(tag);
-        String longName = "x" .repeat(101);
+        String longName = "x".repeat(101);
         UpdateTagRequest req = new UpdateTagRequest(longName, "desc");
         mockMvc.perform(patch("/api/v1/tags/{id}", tag.getId())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -222,7 +222,7 @@ public class TagControllerIntegrationTest {
         Tag tag = new Tag();
         tag.setName("OK");
         tagRepository.save(tag);
-        String longDesc = "d" .repeat(1001);
+        String longDesc = "d".repeat(1001);
         UpdateTagRequest req = new UpdateTagRequest("Valid", longDesc);
         mockMvc.perform(patch("/api/v1/tags/{id}", tag.getId())
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/uk/gegc/quizmaker/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/uk/gegc/quizmaker/security/JwtAuthenticationFilterTest.java
@@ -36,20 +36,20 @@ public class JwtAuthenticationFilterTest {
     JwtAuthenticationFilter authenticationFilter;
 
     @BeforeEach
-    void setUp(){
+    void setUp() {
         MockitoAnnotations.openMocks(this);
         authenticationFilter = new JwtAuthenticationFilter(jwtTokenProvider);
         SecurityContextHolder.clearContext();
     }
 
     @AfterEach
-    void tearDown(){
+    void tearDown() {
         SecurityContextHolder.clearContext();
     }
 
     @Test
     @DisplayName("No authorizetion header -> filterchain invoked, no Authentication set")
-    void noHeader_shouldNotSetAuthentication() throws ServletException, IOException{
+    void noHeader_shouldNotSetAuthentication() throws ServletException, IOException {
         when(httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn(null);
 
         authenticationFilter.doFilterInternal(httpServletRequest, httpServletResponse, filterChain);
@@ -60,7 +60,7 @@ public class JwtAuthenticationFilterTest {
 
     @Test
     @DisplayName("Bearer valid-token → filterChain invoked, Authentication set to returned value")
-    void validBearer_shouldSetAuthentication() throws ServletException, IOException{
+    void validBearer_shouldSetAuthentication() throws ServletException, IOException {
         String token = "valid-token";
         Authentication authentication = mock(Authentication.class);
 

--- a/src/test/java/uk/gegc/quizmaker/security/JwtTokenProviderTest.java
+++ b/src/test/java/uk/gegc/quizmaker/security/JwtTokenProviderTest.java
@@ -23,14 +23,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class JwtTokenProviderTest {
 
-    private JwtTokenProvider jwtTokenProvider;
-    private SecretKey secretKey;
     private final long accessTokenValidityInMs = 15 * 60 * 1000;
     private final long refreshTokenValidityInMs = 7 * 24 * 60 * 60 * 1000;
+    private JwtTokenProvider jwtTokenProvider;
+    private SecretKey secretKey;
     private String base64Secret;
 
     @BeforeEach
-    void setUp(){
+    void setUp() {
         secretKey = Jwts.SIG.HS256.key().build();
         base64Secret = Base64.getEncoder().encodeToString(secretKey.getEncoded());
 
@@ -44,7 +44,7 @@ public class JwtTokenProviderTest {
 
     @Test
     @DisplayName("generateAccessToken: valid Authentication produces JWT with type=access, correct subject & TTL")
-    void generateAccessToken_happyPath_containsAccessTypeAndSubjectAndExpiry(){
+    void generateAccessToken_happyPath_containsAccessTypeAndSubjectAndExpiry() {
         Authentication authentication = new UsernamePasswordAuthenticationToken(
                 "Alice", null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
         );
@@ -70,7 +70,7 @@ public class JwtTokenProviderTest {
 
     @Test
     @DisplayName("generateAccessToken: two quick calls yield different issuedAt & expiration timestamps")
-    void generateAccessToken_edge_twoCalls_differentIssuedAtAndExpiry() throws InterruptedException{
+    void generateAccessToken_edge_twoCalls_differentIssuedAtAndExpiry() throws InterruptedException {
         Authentication authentication = new UsernamePasswordAuthenticationToken("Bob", null, List.of());
 
         String token1 = jwtTokenProvider.generateAccessToken(authentication);
@@ -111,7 +111,7 @@ public class JwtTokenProviderTest {
 
     @Test
     @DisplayName("validateToken: valid access token returns true")
-    void validateToken_happyPath_validTokenReturnsTrue(){
+    void validateToken_happyPath_validTokenReturnsTrue() {
         Authentication authentication = new UsernamePasswordAuthenticationToken("John", null, List.of());
         String validToken = jwtTokenProvider.generateAccessToken(authentication);
 
@@ -121,15 +121,15 @@ public class JwtTokenProviderTest {
 
     @Test
     @DisplayName("validateToken: malformed token returns false")
-    void validateToken_sad_malformedTokenReturnsFalse(){
+    void validateToken_sad_malformedTokenReturnsFalse() {
         String badToken = "not.a.token";
         assertThat(jwtTokenProvider.validateToken(badToken)).isFalse();
     }
 
     @Test
     @DisplayName("validateToken: expired token returns false")
-    void validateToken_sad_expiredTokenReturnsFalse(){
-        Date past = new Date(System.currentTimeMillis()-1000);
+    void validateToken_sad_expiredTokenReturnsFalse() {
+        Date past = new Date(System.currentTimeMillis() - 1000);
         String expired = Jwts.builder()
                 .subject("Eve")
                 .issuedAt(past)
@@ -143,7 +143,7 @@ public class JwtTokenProviderTest {
 
     @Test
     @DisplayName("validateToken: token signed with wrong key returns false")
-    void validateToken_sad_wrongSignatureReturnsFalse(){
+    void validateToken_sad_wrongSignatureReturnsFalse() {
         SecretKey wrongKey = Jwts.SIG.HS256.key().build();
         Date now = new Date();
         String badSignature = Jwts.builder()
@@ -159,7 +159,7 @@ public class JwtTokenProviderTest {
 
     @Test
     @DisplayName("getUsername: valid token returns correct subject")
-    void getUsername_happyPath_returnsCorrectUsername(){
+    void getUsername_happyPath_returnsCorrectUsername() {
         Authentication authentication = new UsernamePasswordAuthenticationToken("Lenny", null, List.of());
 
         String token = jwtTokenProvider.generateRefreshToken(authentication);
@@ -169,7 +169,7 @@ public class JwtTokenProviderTest {
 
     @Test
     @DisplayName("getUsername: invalid token throws JwtException")
-    void getUsername_sad_invalidTokenThrows(){
+    void getUsername_sad_invalidTokenThrows() {
         String badToken = "not.a.token";
         assertThatThrownBy(() -> jwtTokenProvider.getUsername(badToken)).isInstanceOf(JwtException.class);
     }
@@ -194,11 +194,12 @@ public class JwtTokenProviderTest {
         assertThat(result.getName()).isEqualTo("Bill");
         assertThat(result.getAuthorities())
                 .extracting("authority")
-                .containsExactly("ROLE_USER");    }
+                .containsExactly("ROLE_USER");
+    }
 
     @Test
     @DisplayName("getAuthentication: invalid token throws JwtException")
-    void getAuthentication_sad_invalidTokenThrows(){
+    void getAuthentication_sad_invalidTokenThrows() {
         UserDetailsService userDetailsService = username -> new User(username, "", List.of());
         JwtTokenProvider provider = new JwtTokenProvider(null, userDetailsService);
         ReflectionTestUtils.setField(provider, "base64secret", base64Secret);

--- a/src/test/java/uk/gegc/quizmaker/security/QuizUserDetailsServiceTest.java
+++ b/src/test/java/uk/gegc/quizmaker/security/QuizUserDetailsServiceTest.java
@@ -29,7 +29,7 @@ public class QuizUserDetailsServiceTest {
 
     @Test
     @DisplayName("loadUserByUsername: happy when user exists by username")
-    void loadUserByUsername_happy(){
+    void loadUserByUsername_happy() {
         User user = new User();
         user.setUsername("johndoe");
         user.setHashedPassword("hashedPassword");

--- a/src/test/java/uk/gegc/quizmaker/service/attempt/AttemptServiceImplTest.java
+++ b/src/test/java/uk/gegc/quizmaker/service/attempt/AttemptServiceImplTest.java
@@ -1,0 +1,83 @@
+package uk.gegc.quizmaker.service.attempt;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gegc.quizmaker.dto.result.LeaderboardEntryDto;
+import uk.gegc.quizmaker.exception.ResourceNotFoundException;
+import uk.gegc.quizmaker.model.quiz.Quiz;
+import uk.gegc.quizmaker.repository.attempt.AttemptRepository;
+import uk.gegc.quizmaker.repository.quiz.QuizRepository;
+import uk.gegc.quizmaker.service.attempt.impl.AttemptServiceImpl;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AttemptServiceImplTest {
+
+    @Mock QuizRepository quizRepository;
+    @Mock AttemptRepository attemptRepository;
+
+    @InjectMocks AttemptServiceImpl service;
+
+    @Test
+    @DisplayName("getLeaderboard returns top N ordered by score")
+    void getLeaderboard_basic() {
+        UUID quizId = UUID.randomUUID();
+        when(quizRepository.findById(quizId)).thenReturn(Optional.of(new Quiz()));
+        UUID u1 = UUID.randomUUID();
+        UUID u2 = UUID.randomUUID();
+        UUID u3 = UUID.randomUUID();
+        List<Object[]> rows = List.of(
+                new Object[]{u1, "alice", 90.0},
+                new Object[]{u2, "bob", 80.0},
+                new Object[]{u3, "carol", 70.0}
+        );
+        when(attemptRepository.getLeaderboardData(quizId)).thenReturn(rows);
+
+        List<LeaderboardEntryDto> result = service.getQuizLeaderboard(quizId, 2);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).userId()).isEqualTo(u1);
+        assertThat(result.get(0).bestScore()).isEqualTo(90.0);
+        assertThat(result.get(1).userId()).isEqualTo(u2);
+    }
+
+    @Test
+    @DisplayName("getLeaderboard handles ties and insufficient participants")
+    void getLeaderboard_tiesAndShortList() {
+        UUID quizId = UUID.randomUUID();
+        when(quizRepository.findById(quizId)).thenReturn(Optional.of(new Quiz()));
+        UUID u1 = UUID.randomUUID();
+        UUID u2 = UUID.randomUUID();
+        List<Object[]> rows = List.of(
+                new Object[]{u1, "alice", 50.0},
+                new Object[]{u2, "bob", 50.0}
+        );
+        when(attemptRepository.getLeaderboardData(quizId)).thenReturn(rows);
+
+        List<LeaderboardEntryDto> result = service.getQuizLeaderboard(quizId, 5);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).bestScore()).isEqualTo(50.0);
+        assertThat(result.get(1).bestScore()).isEqualTo(50.0);
+    }
+
+    @Test
+    @DisplayName("getLeaderboard throws when quiz not found")
+    void getLeaderboard_quizMissing() {
+        UUID quizId = UUID.randomUUID();
+        when(quizRepository.findById(quizId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getQuizLeaderboard(quizId, 3))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/src/test/java/uk/gegc/quizmaker/service/auth/AuthServiceImplTest.java
+++ b/src/test/java/uk/gegc/quizmaker/service/auth/AuthServiceImplTest.java
@@ -43,19 +43,26 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class AuthServiceImplTest {
 
-    @Mock private UserRepository userRepository;
-    @Mock private PasswordEncoder passwordEncoder;
-    @Mock private RoleRepository roleRepository;
-    @Mock private UserMapper userMapper;
-    @Mock private AuthenticationManager authManager;
-    @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private RoleRepository roleRepository;
+    @Mock
+    private UserMapper userMapper;
+    @Mock
+    private AuthenticationManager authManager;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
 
-    @InjectMocks private AuthServiceImpl authService;
+    @InjectMocks
+    private AuthServiceImpl authService;
 
     @Test
     @DisplayName("register: saves new user and returns UserDto")
     void register_happy() {
-        var req = new RegisterRequest("john","john@example.com","secret123");
+        var req = new RegisterRequest("john", "john@example.com", "secret123");
         when(userRepository.existsByUsername("john")).thenReturn(false);
         when(userRepository.existsByEmail("john@example.com")).thenReturn(false);
 
@@ -104,7 +111,7 @@ class AuthServiceImplTest {
     @Test
     @DisplayName("register: duplicate username yields 409")
     void register_duplicateUsername() {
-        var req = new RegisterRequest("john","john@example.com","secret123");
+        var req = new RegisterRequest("john", "john@example.com", "secret123");
         when(userRepository.existsByUsername("john")).thenReturn(true);
 
         var ex = assertThrows(ResponseStatusException.class,
@@ -115,7 +122,7 @@ class AuthServiceImplTest {
     @Test
     @DisplayName("register: duplicate email yields 409")
     void register_duplicateEmail() {
-        var req = new RegisterRequest("john","john@example.com","secret123");
+        var req = new RegisterRequest("john", "john@example.com", "secret123");
         when(userRepository.existsByUsername("john")).thenReturn(false);
         when(userRepository.existsByEmail("john@example.com")).thenReturn(true);
 
@@ -127,7 +134,7 @@ class AuthServiceImplTest {
     @Test
     @DisplayName("login: correct credentials returns tokens")
     void login_happy() {
-        var req = new LoginRequest("john","pass");
+        var req = new LoginRequest("john", "pass");
         Authentication auth = mock(Authentication.class);
         when(authManager.authenticate(any()))
                 .thenReturn(auth);
@@ -151,7 +158,7 @@ class AuthServiceImplTest {
     @Test
     @DisplayName("login: invalid credentials yields UnauthorizedException")
     void login_badCredits() {
-        var req = new LoginRequest("john","wrong");
+        var req = new LoginRequest("john", "wrong");
         when(authManager.authenticate(any()))
                 .thenThrow(new BadCredentialsException("Bad creds"));
 

--- a/src/test/java/uk/gegc/quizmaker/service/category/CategoryServiceImplTest.java
+++ b/src/test/java/uk/gegc/quizmaker/service/category/CategoryServiceImplTest.java
@@ -32,9 +32,12 @@ import static org.mockito.Mockito.*;
 @DisplayName("CategoryServiceImpl Unit Tests")
 class CategoryServiceImplTest {
 
-    @Mock private CategoryRepository categoryRepository;
-    @Mock private CategoryMapper categoryMapper;
-    @InjectMocks private CategoryServiceImpl service;
+    @Mock
+    private CategoryRepository categoryRepository;
+    @Mock
+    private CategoryMapper categoryMapper;
+    @InjectMocks
+    private CategoryServiceImpl service;
 
     private Category entity;
     private CategoryDto dto;

--- a/src/test/java/uk/gegc/quizmaker/service/question/impl/QuestionServiceImplTest.java
+++ b/src/test/java/uk/gegc/quizmaker/service/question/impl/QuestionServiceImplTest.java
@@ -40,13 +40,19 @@ class QuestionServiceImplTest {
 
     private static final String DUMMY_USER = "testUser";
 
-    @Mock private QuestionRepository questionRepository;
-    @Mock private QuizRepository quizRepository;
-    @Mock private TagRepository tagRepository;
-    @Mock private QuestionHandlerFactory factory;
-    @Mock private QuestionHandler handler;
+    @Mock
+    private QuestionRepository questionRepository;
+    @Mock
+    private QuizRepository quizRepository;
+    @Mock
+    private TagRepository tagRepository;
+    @Mock
+    private QuestionHandlerFactory factory;
+    @Mock
+    private QuestionHandler handler;
 
-    @InjectMocks private QuestionServiceImpl questionService;
+    @InjectMocks
+    private QuestionServiceImpl questionService;
 
     private ObjectMapper objectMapper;
 
@@ -223,7 +229,9 @@ class QuestionServiceImplTest {
         existing.setId(id);
 
         when(questionRepository.findById(id)).thenReturn(Optional.of(existing));
-        when(tagRepository.findById(tagId)).thenReturn(Optional.of(new Tag() {{ setId(tagId); }}));
+        when(tagRepository.findById(tagId)).thenReturn(Optional.of(new Tag() {{
+            setId(tagId);
+        }}));
         when(questionRepository.save(existing)).thenReturn(existing);
 
         var req = new UpdateQuestionRequest();


### PR DESCRIPTION
**Summary**
Implemented a leaderboard feature showing the top participants for each quiz:

- /api/v1/quizzes/{quizId}/leaderboard returns ranked scores, configurable via top parameter (defaults to 10).
- DTOs, repository query, service logic, and controller endpoint were added.
- Integration tests cover normal usage, ties, missing attempts, invalid top values, and the quiz-not-found case.
- Unit tests verify service behaviour.