### PR TITLE
@gegcuk feat(attempt): return first question when starting an attempt

### DIFF
--- a/src/main/java/uk/gegc/quizmaker/controller/AttemptController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/AttemptController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -42,17 +43,18 @@ public class AttemptController {
             description = "Creates a new attempt for the given quiz and returns its ID."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "Attempt started successfully",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(
-                                    example = "{\"attemptId\":\"3fa85f64-5717-4562-b3fc-2c963f66afa6\"}"
-                            )
-                    )
-            ),
+            @ApiResponse(responseCode = "201", description = "Attempt started",
+                    content = @Content(schema = @Schema(implementation = StartAttemptResponse.class),
+                            examples = @ExampleObject(name = "success", value = """
+                            {
+                              "attemptId":"3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                              "firstQuestion":null
+                            }
+                            """))) ,
             @ApiResponse(responseCode = "404", description = "Quiz not found")
     })
     @PostMapping("/quizzes/{quizId}")
-    public ResponseEntity<Map<String, UUID>> startAttempt(
+    public ResponseEntity<StartAttemptResponse> startAttempt(
             @Parameter(description = "Quiz UUID to start an attempt for", required = true)
             @PathVariable UUID quizId,
 
@@ -71,9 +73,8 @@ public class AttemptController {
         AttemptMode mode = (request != null && request.mode() != null)
                 ? request.mode()
                 : AttemptMode.ALL_AT_ONCE;
-        AttemptDto dto = attemptService.startAttempt(username, quizId, mode);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(Map.of("attemptId", dto.attemptId()));
+        StartAttemptResponse dto = attemptService.startAttempt(username, quizId, mode);
+        return ResponseEntity.status(HttpStatus.CREATED).body(dto);
     }
 
     @Operation(

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/StartAttemptResponse.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/StartAttemptResponse.java
@@ -1,0 +1,13 @@
+package uk.gegc.quizmaker.dto.attempt;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import uk.gegc.quizmaker.dto.question.QuestionDto;
+
+import java.util.UUID;
+
+@Schema(name = "StartAttemptResponse",
+        description = "Attempt ID plus the first question (if any)")
+public record StartAttemptResponse(
+        @Schema(description = "Attempt UUID") UUID attemptId,
+        @Schema(description = "First question to answer") QuestionDto firstQuestion
+) {}

--- a/src/main/java/uk/gegc/quizmaker/service/attempt/AttemptService.java
+++ b/src/main/java/uk/gegc/quizmaker/service/attempt/AttemptService.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.UUID;
 
 public interface AttemptService {
-    AttemptDto startAttempt(String username, UUID quizId, AttemptMode mode);
+    StartAttemptResponse startAttempt(String username, UUID quizId, AttemptMode mode);
 
     Page<AttemptDto> getAttempts(String username, Pageable pageable, UUID quizId, UUID userId);
 

--- a/src/main/java/uk/gegc/quizmaker/service/attempt/impl/AttemptServiceImpl.java
+++ b/src/main/java/uk/gegc/quizmaker/service/attempt/impl/AttemptServiceImpl.java
@@ -54,7 +54,7 @@ public class AttemptServiceImpl implements AttemptService {
     private final ScoringService scoringService;
 
     @Override
-    public AttemptDto startAttempt(String username, UUID quizId, AttemptMode mode) {
+    public StartAttemptResponse startAttempt(String username, UUID quizId, AttemptMode mode) {
         User user = userRepository.findByUsername(username)
                 .or(() -> userRepository.findByEmail(username))
                 .orElseThrow(() -> new ResourceNotFoundException("User " + username + " not found"));
@@ -69,7 +69,10 @@ public class AttemptServiceImpl implements AttemptService {
         attempt.setStatus(AttemptStatus.IN_PROGRESS);
 
         Attempt saved = attemptRepository.save(attempt);
-        return attemptMapper.toDto(saved);
+        Question first = quiz.getQuestions().stream().findFirst().orElse(null);
+        QuestionDto dto = first != null ? QuestionMapper.toDto(first) : null;
+
+        return new StartAttemptResponse(saved.getId(), dto);
     }
 
     @Override

--- a/src/test/java/uk/gegc/quizmaker/controller/AttemptControllerIntegrationTest.java
+++ b/src/test/java/uk/gegc/quizmaker/controller/AttemptControllerIntegrationTest.java
@@ -726,6 +726,26 @@ public class AttemptControllerIntegrationTest {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    @DisplayName("startAttempt returns first question")
+    void startAttempt_returnsFirstQuestion() throws Exception {
+        UUID questionId = createDummyQuestion(TRUE_FALSE, "{\"answer\":true}");
+
+        mockMvc.perform(post("/api/v1/attempts/quizzes/{id}", quizId))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.attemptId").exists())
+                .andExpect(jsonPath("$.firstQuestion.id", is(questionId.toString())));
+    }
+
+    @Test
+    @DisplayName("startAttempt quiz has no questions returns null firstQuestion")
+    void startAttempt_quizHasNoQuestions_returnsNullFirstQuestion() throws Exception {
+        mockMvc.perform(post("/api/v1/attempts/quizzes/{id}", quizId))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.attemptId").exists())
+                .andExpect(jsonPath("$.firstQuestion").value(nullValue()));
+    }
+
     private ResultActions postAnswer(UUID attempt, UUID question, String responseJson) throws Exception {
         var request = new AnswerSubmissionRequest(question, objectMapper.readTree(responseJson));
         return mockMvc.perform(post("/api/v1/attempts/{id}/answers", attempt)


### PR DESCRIPTION
**API**
• `POST /api/v1/attempts/quizzes/{quizId}` now returns
  `StartAttemptResponse { attemptId, firstQuestion }` instead of a
  plain map – zero extra round-trip needed to show the first question.

**Code**
• Added `StartAttemptResponse` record (+ Swagger @Schema). • `AttemptService.startAttempt(..)` returns the new DTO and picks the
  first `Question` (or `null` if the quiz is empty).
• Updated `AttemptController` to emit the new response, refreshed
  `@Operation` / `@ApiResponse` with an example payload.
• Adapted mapper/logic in `AttemptServiceImpl`.

**Tests**
• `startAttempt_returnsFirstQuestion` – happy-path with question. • `startAttempt_quizHasNoQuestions_returnsNullFirstQuestion` – edge
  case with empty quiz.
• Adjusted previous start-attempt assertions to expect the new JSON.

**Docs**
• Swagger UI now shows the enriched response for quicker onboarding.

BREAKING CHANGE: clients must read `"firstQuestion"` instead of calling an extra endpoint to fetch it.

Closes #96 