### PR TITLE
Implement current question retrieval for attempts and enhance reposit…

### DIFF
--- a/src/main/java/uk/gegc/quizmaker/controller/AttemptController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/AttemptController.java
@@ -133,8 +133,46 @@ public class AttemptController {
             Authentication authentication
     ) {
         String username = authentication.getName();
-        AttemptDetailsDto details = attemptService.getAttemptDetail(username, attemptId);
-        return ResponseEntity.ok(details);
+        AttemptDetailsDto attempt = attemptService.getAttemptDetail(username, attemptId);
+        return ResponseEntity.ok(attempt);
+    }
+
+    @Operation(
+            summary = "Get current question for an attempt",
+            description = "Retrieve the current question for an in-progress attempt. This is useful when resuming an attempt after closing the browser."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Current question returned",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CurrentQuestionDto.class),
+                            examples = @ExampleObject(name = "success", value = """
+                                    {
+                                      "question": {
+                                        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                                        "type": "MULTIPLE_CHOICE",
+                                        "content": "What is the capital of France?",
+                                        "options": ["London", "Berlin", "Paris", "Madrid"]
+                                      },
+                                      "questionNumber": 3,
+                                      "totalQuestions": 10,
+                                      "attemptStatus": "IN_PROGRESS"
+                                    }
+                                    """))
+            ),
+            @ApiResponse(responseCode = "404", description = "Attempt not found"),
+            @ApiResponse(responseCode = "409", description = "Attempt is not in progress or all questions answered")
+    })
+    @GetMapping("/{attemptId}/current-question")
+    public ResponseEntity<CurrentQuestionDto> getCurrentQuestion(
+            @Parameter(description = "UUID of the attempt", required = true)
+            @PathVariable UUID attemptId,
+
+            Authentication authentication
+    ) {
+        String username = authentication.getName();
+        CurrentQuestionDto currentQuestion = attemptService.getCurrentQuestion(username, attemptId);
+        return ResponseEntity.ok(currentQuestion);
     }
 
     @Operation(summary = "Submit a single answer", description = "Submit an answer to a specific question within an attempt.")

--- a/src/main/java/uk/gegc/quizmaker/dto/attempt/CurrentQuestionDto.java
+++ b/src/main/java/uk/gegc/quizmaker/dto/attempt/CurrentQuestionDto.java
@@ -1,0 +1,21 @@
+package uk.gegc.quizmaker.dto.attempt;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import uk.gegc.quizmaker.dto.question.QuestionForAttemptDto;
+import uk.gegc.quizmaker.model.attempt.AttemptStatus;
+
+@Schema(name = "CurrentQuestionDto", description = "Current question for an existing attempt with progress information")
+public record CurrentQuestionDto(
+        @Schema(description = "Current question (safe version without correct answers)")
+        QuestionForAttemptDto question,
+
+        @Schema(description = "Current question number (1-based)", example = "3")
+        int questionNumber,
+
+        @Schema(description = "Total number of questions in the quiz", example = "10")
+        int totalQuestions,
+
+        @Schema(description = "Current status of the attempt", example = "IN_PROGRESS")
+        AttemptStatus attemptStatus
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/repository/attempt/AttemptRepository.java
+++ b/src/main/java/uk/gegc/quizmaker/repository/attempt/AttemptRepository.java
@@ -48,7 +48,7 @@ public interface AttemptRepository extends JpaRepository<Attempt, UUID> {
     Optional<Attempt> findByIdWithAnswersAndQuestion(@Param("id") UUID id);
 
     @Query("""
-            SELECT a
+            SELECT DISTINCT a
             FROM Attempt a
             LEFT JOIN FETCH a.answers ans
             LEFT JOIN FETCH ans.question q

--- a/src/main/java/uk/gegc/quizmaker/repository/question/AnswerRepository.java
+++ b/src/main/java/uk/gegc/quizmaker/repository/question/AnswerRepository.java
@@ -1,9 +1,14 @@
 package uk.gegc.quizmaker.repository.question;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import uk.gegc.quizmaker.model.question.Answer;
 
 import java.util.UUID;
 
 public interface AnswerRepository extends JpaRepository<Answer, UUID> {
+    
+    @Query("SELECT COUNT(a) FROM Answer a WHERE a.attempt.id = :attemptId")
+    long countByAttemptId(@Param("attemptId") UUID attemptId);
 }

--- a/src/main/java/uk/gegc/quizmaker/service/attempt/AttemptService.java
+++ b/src/main/java/uk/gegc/quizmaker/service/attempt/AttemptService.java
@@ -40,6 +40,19 @@ public interface AttemptService {
 
     AttemptDto resumeAttempt(String username, UUID attemptId);
 
+    /**
+     * Get the current question for an existing attempt.
+     * This is useful when a user wants to resume an attempt and needs to see the current question.
+     *
+     * @param username  the username of the authenticated user
+     * @param attemptId the UUID of the attempt
+     * @return CurrentQuestionDto containing the current question and progress information
+     * @throws ResourceNotFoundException if the attempt is not found
+     * @throws AccessDeniedException if the user doesn't own the attempt
+     * @throws IllegalStateException if the attempt is not in progress or all questions are answered
+     */
+    CurrentQuestionDto getCurrentQuestion(String username, UUID attemptId);
+
     // 👨‍💼 Admin Functions
     List<AttemptDto> getAttemptsByDateRange(LocalDate start, LocalDate end);
 

--- a/src/test/java/uk/gegc/quizmaker/controller/AttemptControllerCurrentQuestionIntegrationTest.java
+++ b/src/test/java/uk/gegc/quizmaker/controller/AttemptControllerCurrentQuestionIntegrationTest.java
@@ -1,0 +1,291 @@
+package uk.gegc.quizmaker.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import uk.gegc.quizmaker.model.attempt.AttemptMode;
+import uk.gegc.quizmaker.model.attempt.AttemptStatus;
+import uk.gegc.quizmaker.model.question.Difficulty;
+import uk.gegc.quizmaker.model.question.Question;
+import uk.gegc.quizmaker.model.question.QuestionType;
+import uk.gegc.quizmaker.model.quiz.Quiz;
+import uk.gegc.quizmaker.model.user.User;
+import uk.gegc.quizmaker.repository.attempt.AttemptRepository;
+import uk.gegc.quizmaker.repository.question.QuestionRepository;
+import uk.gegc.quizmaker.repository.quiz.QuizRepository;
+import uk.gegc.quizmaker.repository.user.UserRepository;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.List;
+import java.util.Comparator;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest
+@AutoConfigureWebMvc
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class AttemptControllerCurrentQuestionIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private QuizRepository quizRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private AttemptRepository attemptRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MockMvc mockMvc;
+    private User testUser;
+    private Quiz testQuiz;
+    private Question question1;
+    private Question question2;
+    private uk.gegc.quizmaker.model.attempt.Attempt testAttempt;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+
+        // Clean up any existing test data first
+        userRepository.findByUsername("testuser").ifPresent(userRepository::delete);
+        userRepository.findByEmail("test@example.com").ifPresent(userRepository::delete);
+        
+        // Use unique names with timestamp to avoid conflicts
+        String timestamp = String.valueOf(System.currentTimeMillis());
+        String uniqueEmail = "test_" + timestamp + "@example.com";
+        String uniqueQuizTitle = "Test Quiz " + timestamp;
+        String uniqueCategoryName = "Test Category " + timestamp;
+
+        // Create test user with fixed username
+        testUser = new User();
+        testUser.setUsername("testuser");
+        testUser.setEmail(uniqueEmail);
+        testUser.setHashedPassword("password123");
+        testUser = userRepository.save(testUser);
+
+        // Create test category (required for quiz)
+        uk.gegc.quizmaker.model.category.Category testCategory = new uk.gegc.quizmaker.model.category.Category();
+        testCategory.setName(uniqueCategoryName);
+        testCategory.setDescription("A test category");
+        testCategory = context.getBean(uk.gegc.quizmaker.repository.category.CategoryRepository.class).save(testCategory);
+
+        // Create test quiz
+        testQuiz = new Quiz();
+        testQuiz.setTitle(uniqueQuizTitle);
+        testQuiz.setDescription("A test quiz");
+        testQuiz.setCreator(testUser);
+        testQuiz.setCategory(testCategory);
+        testQuiz.setVisibility(uk.gegc.quizmaker.model.quiz.Visibility.PUBLIC);
+        testQuiz.setStatus(uk.gegc.quizmaker.model.quiz.QuizStatus.PUBLISHED);
+        testQuiz.setDifficulty(uk.gegc.quizmaker.model.question.Difficulty.EASY);
+        testQuiz.setEstimatedTime(10);
+        testQuiz.setIsRepetitionEnabled(false);
+        testQuiz.setIsTimerEnabled(false);
+        testQuiz.setIsDeleted(false);
+        testQuiz = quizRepository.save(testQuiz);
+
+        // Create questions
+        question1 = new Question();
+        question1.setType(QuestionType.MCQ_SINGLE);
+        question1.setQuestionText("What is the capital of France?");
+        question1.setContent("""
+                {
+                  "options": [
+                    {"id": "1", "text": "London", "correct": false},
+                    {"id": "2", "text": "Berlin", "correct": false},
+                    {"id": "3", "text": "Paris", "correct": true},
+                    {"id": "4", "text": "Madrid", "correct": false}
+                  ]
+                }
+                """);
+        question1.setDifficulty(Difficulty.EASY);
+        question1.setHint("Think about the Eiffel Tower");
+        question1.setExplanation("Paris is the capital and largest city of France.");
+        question1.setIsDeleted(false);
+        question1 = questionRepository.save(question1);
+
+        question2 = new Question();
+        question2.setType(QuestionType.MCQ_SINGLE);
+        question2.setQuestionText("What is 2 + 2?");
+        question2.setContent("""
+                {
+                  "options": [
+                    {"id": "1", "text": "3", "correct": false},
+                    {"id": "2", "text": "4", "correct": true},
+                    {"id": "3", "text": "5", "correct": false},
+                    {"id": "4", "text": "6", "correct": false}
+                  ]
+                }
+                """);
+        question2.setDifficulty(Difficulty.EASY);
+        question2.setHint("Basic arithmetic");
+        question2.setExplanation("2 + 2 = 4 is a fundamental mathematical fact.");
+        question2.setIsDeleted(false);
+        question2 = questionRepository.save(question2);
+
+        // Add questions to quiz
+        Set<Question> questions = new HashSet<>();
+        questions.add(question1);
+        questions.add(question2);
+        testQuiz.setQuestions(questions);
+        testQuiz = quizRepository.save(testQuiz);
+
+        // Create test attempt
+        testAttempt = new uk.gegc.quizmaker.model.attempt.Attempt();
+        testAttempt.setUser(testUser);
+        testAttempt.setQuiz(testQuiz);
+        testAttempt.setMode(AttemptMode.ONE_BY_ONE);
+        testAttempt.setStatus(AttemptStatus.IN_PROGRESS);
+        testAttempt.setStartedAt(Instant.now());
+        testAttempt.setAnswers(new java.util.ArrayList<>());
+        testAttempt = attemptRepository.save(testAttempt);
+    }
+
+    @Test
+    @WithMockUser(username = "testuser")
+    void getCurrentQuestion_FirstQuestion_ReturnsFirstQuestion() throws Exception {
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/attempts/{attemptId}/current-question", testAttempt.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.questionNumber").value(1))
+                .andExpect(jsonPath("$.totalQuestions").value(2))
+                .andExpect(jsonPath("$.attemptStatus").value("IN_PROGRESS"))
+                .andExpect(jsonPath("$.question.id").exists())
+                .andExpect(jsonPath("$.question.type").value("MCQ_SINGLE"))
+                .andExpect(jsonPath("$.question.difficulty").value("EASY"));
+    }
+
+    @Test
+    @WithMockUser(username = "testuser")
+    void getCurrentQuestion_SecondQuestion_ReturnsSecondQuestion() throws Exception {
+        // Arrange - Add one answer to simulate first question answered
+        // We need to get the first question from the sorted list to answer it
+        List<Question> sortedQuestions = testQuiz.getQuestions().stream()
+                .sorted(Comparator.comparing(Question::getId))
+                .collect(java.util.stream.Collectors.toList());
+        Question firstQuestion = sortedQuestions.get(0);
+        
+        uk.gegc.quizmaker.model.question.Answer answer = new uk.gegc.quizmaker.model.question.Answer();
+        answer.setQuestion(firstQuestion);
+        answer.setAnsweredAt(Instant.now());
+        answer.setAttempt(testAttempt);
+        answer.setResponse("{\"selectedOption\": \"4\"}");  // User selected "4" as answer
+        answer.setIsCorrect(true);
+        answer.setScore(1.0);
+        
+        // Save the answer separately to ensure it's persisted
+        uk.gegc.quizmaker.repository.question.AnswerRepository answerRepo = context.getBean(uk.gegc.quizmaker.repository.question.AnswerRepository.class);
+        answerRepo.save(answer);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/attempts/{attemptId}/current-question", testAttempt.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.questionNumber").value(2))
+                .andExpect(jsonPath("$.totalQuestions").value(2))
+                .andExpect(jsonPath("$.attemptStatus").value("IN_PROGRESS"))
+                .andExpect(jsonPath("$.question.id").exists())
+                .andExpect(jsonPath("$.question.type").value("MCQ_SINGLE"))
+                .andExpect(jsonPath("$.question.difficulty").value("EASY"));
+    }
+
+    @Test
+    @WithMockUser(username = "testuser")
+    void getCurrentQuestion_AttemptNotFound_Returns404() throws Exception {
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/attempts/{attemptId}/current-question", UUID.randomUUID())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = "wronguser")
+    void getCurrentQuestion_WrongUser_Returns403() throws Exception {
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/attempts/{attemptId}/current-question", testAttempt.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "testuser")
+    void getCurrentQuestion_AttemptCompleted_Returns409() throws Exception {
+        // Arrange - Complete the attempt by updating it directly
+        testAttempt.setStatus(AttemptStatus.COMPLETED);
+        testAttempt.setCompletedAt(Instant.now());
+        attemptRepository.saveAndFlush(testAttempt);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/attempts/{attemptId}/current-question", testAttempt.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.error").value("Conflict"));
+    }
+
+    @Test
+    @WithMockUser(username = "testuser")
+    void getCurrentQuestion_AllQuestionsAnswered_Returns409() throws Exception {
+        // Arrange - Answer all questions
+        List<Question> sortedQuestions = testQuiz.getQuestions().stream()
+                .sorted(Comparator.comparing(Question::getId))
+                .collect(java.util.stream.Collectors.toList());
+        
+        uk.gegc.quizmaker.model.question.Answer answer1 = new uk.gegc.quizmaker.model.question.Answer();
+        answer1.setQuestion(sortedQuestions.get(0));
+        answer1.setAnsweredAt(Instant.now());
+        answer1.setAttempt(testAttempt);
+        answer1.setResponse("{\"selectedOption\": \"4\"}");  // User selected "4" as answer
+        answer1.setIsCorrect(true);
+        answer1.setScore(1.0);
+
+        uk.gegc.quizmaker.model.question.Answer answer2 = new uk.gegc.quizmaker.model.question.Answer();
+        answer2.setQuestion(sortedQuestions.get(1));
+        answer2.setAnsweredAt(Instant.now());
+        answer2.setAttempt(testAttempt);
+        answer2.setResponse("{\"selectedOption\": \"6\"}");  // User selected "6" as answer
+        answer2.setIsCorrect(true);
+        answer2.setScore(1.0);
+
+        testAttempt.getAnswers().add(answer1);
+        testAttempt.getAnswers().add(answer2);
+        attemptRepository.saveAndFlush(testAttempt);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/v1/attempts/{attemptId}/current-question", testAttempt.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.error").value("Conflict"));
+    }
+}

--- a/src/test/java/uk/gegc/quizmaker/service/attempt/AttemptServiceCurrentQuestionTest.java
+++ b/src/test/java/uk/gegc/quizmaker/service/attempt/AttemptServiceCurrentQuestionTest.java
@@ -1,0 +1,258 @@
+package uk.gegc.quizmaker.service.attempt;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gegc.quizmaker.dto.attempt.CurrentQuestionDto;
+import uk.gegc.quizmaker.dto.question.QuestionForAttemptDto;
+import uk.gegc.quizmaker.exception.ResourceNotFoundException;
+import uk.gegc.quizmaker.mapper.SafeQuestionMapper;
+import uk.gegc.quizmaker.model.attempt.Attempt;
+import uk.gegc.quizmaker.model.attempt.AttemptStatus;
+import uk.gegc.quizmaker.model.question.Difficulty;
+import uk.gegc.quizmaker.model.question.Question;
+import uk.gegc.quizmaker.model.question.QuestionType;
+import uk.gegc.quizmaker.model.quiz.Quiz;
+import uk.gegc.quizmaker.model.user.User;
+import uk.gegc.quizmaker.repository.attempt.AttemptRepository;
+import uk.gegc.quizmaker.repository.question.AnswerRepository;
+import uk.gegc.quizmaker.service.attempt.impl.AttemptServiceImpl;
+
+import java.time.Instant;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AttemptServiceCurrentQuestionTest {
+
+    @Mock
+    private AttemptRepository attemptRepository;
+
+    @Mock
+    private SafeQuestionMapper safeQuestionMapper;
+
+    @Mock
+    private AnswerRepository answerRepository;
+
+    @InjectMocks
+    private AttemptServiceImpl attemptService;
+
+    private User testUser;
+    private Quiz testQuiz;
+    private Attempt testAttempt;
+    private Question question1;
+    private Question question2;
+    private Question question3;
+    private QuestionForAttemptDto safeQuestionDto1;
+    private QuestionForAttemptDto safeQuestionDto2;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        
+        testUser = new User();
+        testUser.setId(UUID.randomUUID());
+        testUser.setUsername("testuser");
+
+        testQuiz = new Quiz();
+        testQuiz.setId(UUID.randomUUID());
+        testQuiz.setTitle("Test Quiz");
+
+        question1 = new Question();
+        question1.setId(UUID.randomUUID());
+        question1.setQuestionText("What is 2+2?");
+        question1.setType(QuestionType.MCQ_SINGLE);
+        question1.setDifficulty(Difficulty.EASY);
+        question1.setContent("{\"question\": \"What is 2+2?\", \"options\": [\"3\", \"4\", \"5\", \"6\"]}");
+
+        question2 = new Question();
+        question2.setId(UUID.randomUUID());
+        question2.setQuestionText("What is 3+3?");
+        question2.setType(QuestionType.MCQ_SINGLE);
+        question2.setDifficulty(Difficulty.EASY);
+        question2.setContent("{\"question\": \"What is 3+3?\", \"options\": [\"5\", \"6\", \"7\", \"8\"]}");
+
+        question3 = new Question();
+        question3.setId(UUID.randomUUID());
+        question3.setQuestionText("What is 4+4?");
+        question3.setType(QuestionType.MCQ_SINGLE);
+        question3.setDifficulty(Difficulty.EASY);
+        question3.setContent("{\"question\": \"What is 4+4?\", \"options\": [\"7\", \"8\", \"9\", \"10\"]}");
+
+        // Set questions in quiz (sorted by ID for consistent ordering)
+        Set<Question> questions = new HashSet<>(Arrays.asList(question1, question2, question3));
+        testQuiz.setQuestions(questions);
+
+        testAttempt = new Attempt();
+        testAttempt.setId(UUID.randomUUID());
+        testAttempt.setUser(testUser);
+        testAttempt.setQuiz(testQuiz);
+        testAttempt.setStatus(AttemptStatus.IN_PROGRESS);
+        testAttempt.setStartedAt(Instant.now());
+        testAttempt.setAnswers(new ArrayList<>());
+
+        // Create safe question DTOs for each question
+        safeQuestionDto1 = new QuestionForAttemptDto();
+        safeQuestionDto1.setId(question1.getId());
+        safeQuestionDto1.setType(QuestionType.MCQ_SINGLE);
+        safeQuestionDto1.setDifficulty(Difficulty.EASY);
+        safeQuestionDto1.setQuestionText("What is 2+2?");
+        try {
+            JsonNode safeContent = objectMapper.readTree("{\"question\": \"What is 2+2?\", \"options\": [\"3\", \"4\", \"5\", \"6\"]}");
+            safeQuestionDto1.setSafeContent(safeContent);
+        } catch (Exception e) {
+            // Ignore for test
+        }
+
+        safeQuestionDto2 = new QuestionForAttemptDto();
+        safeQuestionDto2.setId(question2.getId());
+        safeQuestionDto2.setType(QuestionType.MCQ_SINGLE);
+        safeQuestionDto2.setDifficulty(Difficulty.EASY);
+        safeQuestionDto2.setQuestionText("What is 3+3?");
+        try {
+            JsonNode safeContent = objectMapper.readTree("{\"question\": \"What is 3+3?\", \"options\": [\"5\", \"6\", \"7\", \"8\"]}");
+            safeQuestionDto2.setSafeContent(safeContent);
+        } catch (Exception e) {
+            // Ignore for test
+        }
+    }
+
+    @Test
+    void getCurrentQuestion_FirstQuestion_ReturnsFirstQuestion() {
+        // Arrange
+        UUID attemptId = testAttempt.getId();
+        when(attemptRepository.findFullyLoadedById(attemptId))
+                .thenReturn(Optional.of(testAttempt));
+        when(answerRepository.countByAttemptId(attemptId))
+                .thenReturn(0L);
+        
+        // Use a custom answer that returns different DTOs based on the question
+        when(safeQuestionMapper.toSafeDto(any(Question.class)))
+                .thenAnswer(invocation -> {
+                    Question question = invocation.getArgument(0);
+                    if (question != null && question.getId().equals(question1.getId())) {
+                        return safeQuestionDto1;
+                    } else if (question != null && question.getId().equals(question2.getId())) {
+                        return safeQuestionDto2;
+                    }
+                    return safeQuestionDto1; // Default fallback
+                });
+
+        // Act
+        CurrentQuestionDto result = attemptService.getCurrentQuestion("testuser", attemptId);
+
+        // Assert
+        assertNotNull(result);
+        // Don't check specific question ID since order depends on auto-generated UUIDs
+        assertNotNull(result.question().getId());
+        assertEquals(1, result.questionNumber());
+        assertEquals(3, result.totalQuestions());
+        assertEquals(AttemptStatus.IN_PROGRESS, result.attemptStatus());
+    }
+
+    @Test
+    void getCurrentQuestion_SecondQuestion_ReturnsSecondQuestion() {
+        // Arrange
+        UUID attemptId = testAttempt.getId();
+        when(attemptRepository.findFullyLoadedById(attemptId))
+                .thenReturn(Optional.of(testAttempt));
+        when(answerRepository.countByAttemptId(attemptId))
+                .thenReturn(1L);
+        
+        // Use a custom answer that returns different DTOs based on the question
+        when(safeQuestionMapper.toSafeDto(any(Question.class)))
+                .thenAnswer(invocation -> {
+                    Question question = invocation.getArgument(0);
+                    if (question != null && question.getId().equals(question1.getId())) {
+                        return safeQuestionDto1;
+                    } else if (question != null && question.getId().equals(question2.getId())) {
+                        return safeQuestionDto2;
+                    }
+                    return safeQuestionDto2; // Default fallback
+                });
+
+        // Act
+        CurrentQuestionDto result = attemptService.getCurrentQuestion("testuser", attemptId);
+
+        // Assert
+        assertNotNull(result);
+        // Don't check specific question ID since order depends on auto-generated UUIDs
+        assertNotNull(result.question().getId());
+        assertEquals(2, result.questionNumber());
+        assertEquals(3, result.totalQuestions());
+        assertEquals(AttemptStatus.IN_PROGRESS, result.attemptStatus());
+    }
+
+    @Test
+    void getCurrentQuestion_AttemptNotFound_ThrowsResourceNotFoundException() {
+        // Arrange
+        UUID attemptId = UUID.randomUUID();
+        when(attemptRepository.findFullyLoadedById(attemptId))
+                .thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(ResourceNotFoundException.class, () ->
+                attemptService.getCurrentQuestion("testuser", attemptId));
+    }
+
+    @Test
+    void getCurrentQuestion_WrongUser_ThrowsAccessDeniedException() {
+        // Arrange
+        UUID attemptId = testAttempt.getId();
+        when(attemptRepository.findFullyLoadedById(attemptId))
+                .thenReturn(Optional.of(testAttempt));
+
+        // Act & Assert
+        assertThrows(org.springframework.security.access.AccessDeniedException.class, () ->
+                attemptService.getCurrentQuestion("wronguser", attemptId));
+    }
+
+    @Test
+    void getCurrentQuestion_AttemptNotInProgress_ThrowsIllegalStateException() {
+        // Arrange
+        UUID attemptId = testAttempt.getId();
+        testAttempt.setStatus(AttemptStatus.COMPLETED);
+        when(attemptRepository.findFullyLoadedById(attemptId))
+                .thenReturn(Optional.of(testAttempt));
+
+        // Act & Assert
+        assertThrows(IllegalStateException.class, () ->
+                attemptService.getCurrentQuestion("testuser", attemptId));
+    }
+
+    @Test
+    void getCurrentQuestion_AllQuestionsAnswered_ThrowsIllegalStateException() {
+        // Arrange
+        UUID attemptId = testAttempt.getId();
+        when(attemptRepository.findFullyLoadedById(attemptId))
+                .thenReturn(Optional.of(testAttempt));
+        when(answerRepository.countByAttemptId(attemptId))
+                .thenReturn(3L); // All 3 questions answered
+
+        // Act & Assert
+        assertThrows(IllegalStateException.class, () ->
+                attemptService.getCurrentQuestion("testuser", attemptId));
+    }
+
+    @Test
+    void getCurrentQuestion_QuizHasNoQuestions_ThrowsIllegalStateException() {
+        // Arrange
+        UUID attemptId = testAttempt.getId();
+        testQuiz.setQuestions(new HashSet<>());
+        when(attemptRepository.findFullyLoadedById(attemptId))
+                .thenReturn(Optional.of(testAttempt));
+
+        // Act & Assert
+        assertThrows(IllegalStateException.class, () ->
+                attemptService.getCurrentQuestion("testuser", attemptId));
+    }
+}


### PR DESCRIPTION
…ory queries

- Added a new endpoint in AttemptController to retrieve the current question for an in-progress attempt, improving user experience when resuming attempts.
- Introduced a method in AttemptService to handle the logic for fetching the current question, including validation for attempt status and ownership.
- Updated AttemptRepository to use DISTINCT in queries for better performance and added a new method in AnswerRepository to count answers by attempt ID.
- Enhanced documentation for the new API endpoint and service method, ensuring clarity for future developers and users.