### PR TITLE
Add delete attempt functionality in AttemptController and AttemptService

### DIFF
--- a/src/main/java/uk/gegc/quizmaker/controller/AttemptController.java
+++ b/src/main/java/uk/gegc/quizmaker/controller/AttemptController.java
@@ -314,6 +314,24 @@ public class AttemptController {
         return ResponseEntity.ok(result);
     }
 
+    @Operation(summary = "Delete an attempt", description = "Delete an attempt and all its associated answers. Users can only delete their own attempts.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Attempt deleted successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - User does not own the attempt"),
+            @ApiResponse(responseCode = "404", description = "Attempt not found")
+    })
+    @DeleteMapping("/{attemptId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteAttempt(
+            @Parameter(description = "UUID of the attempt to delete", required = true)
+            @PathVariable UUID attemptId,
+            Authentication authentication
+    ) {
+        String username = authentication.getName();
+        attemptService.deleteAttempt(username, attemptId);
+    }
+
     @Operation(summary = "Get shuffled questions", description = "Get questions for a quiz in randomized order (safe, without answers).")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Shuffled questions returned")

--- a/src/main/java/uk/gegc/quizmaker/repository/question/AnswerRepository.java
+++ b/src/main/java/uk/gegc/quizmaker/repository/question/AnswerRepository.java
@@ -1,14 +1,21 @@
 package uk.gegc.quizmaker.repository.question;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 import uk.gegc.quizmaker.model.question.Answer;
 
 import java.util.UUID;
 
+@Repository
 public interface AnswerRepository extends JpaRepository<Answer, UUID> {
     
     @Query("SELECT COUNT(a) FROM Answer a WHERE a.attempt.id = :attemptId")
     long countByAttemptId(@Param("attemptId") UUID attemptId);
+    
+    @Modifying
+    @Query("DELETE FROM Answer a WHERE a.attempt.id = :attemptId")
+    void deleteByAttemptId(@Param("attemptId") UUID attemptId);
 }

--- a/src/main/java/uk/gegc/quizmaker/service/attempt/AttemptService.java
+++ b/src/main/java/uk/gegc/quizmaker/service/attempt/AttemptService.java
@@ -41,6 +41,17 @@ public interface AttemptService {
     AttemptDto resumeAttempt(String username, UUID attemptId);
 
     /**
+     * Delete an attempt and all its associated answers.
+     * Users can only delete their own attempts.
+     *
+     * @param username  the username of the authenticated user
+     * @param attemptId the UUID of the attempt to delete
+     * @throws ResourceNotFoundException if the attempt is not found
+     * @throws AccessDeniedException if the user doesn't own the attempt
+     */
+    void deleteAttempt(String username, UUID attemptId);
+
+    /**
      * Get the current question for an existing attempt.
      * This is useful when a user wants to resume an attempt and needs to see the current question.
      *

--- a/src/main/java/uk/gegc/quizmaker/service/attempt/impl/AttemptServiceImpl.java
+++ b/src/main/java/uk/gegc/quizmaker/service/attempt/impl/AttemptServiceImpl.java
@@ -476,6 +476,20 @@ public class AttemptServiceImpl implements AttemptService {
     }
 
     @Override
+    @Transactional
+    public void deleteAttempt(String username, UUID attemptId) {
+        Attempt attempt = attemptRepository.findById(attemptId)
+                .orElseThrow(() -> new ResourceNotFoundException("Attempt " + attemptId + " not found"));
+        enforceOwnership(attempt, username);
+
+        // Delete all answers associated with this attempt first
+        answerRepository.deleteByAttemptId(attemptId);
+        
+        // Then delete the attempt itself
+        attemptRepository.delete(attempt);
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public List<AttemptDto> getAttemptsByDateRange(LocalDate start, LocalDate end) {
         Instant startInstant = start.atStartOfDay().atZone(java.time.ZoneOffset.UTC).toInstant();

--- a/src/test/java/uk/gegc/quizmaker/controller/AttemptControllerDeleteIntegrationTest.java
+++ b/src/test/java/uk/gegc/quizmaker/controller/AttemptControllerDeleteIntegrationTest.java
@@ -1,0 +1,128 @@
+package uk.gegc.quizmaker.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import uk.gegc.quizmaker.exception.ResourceNotFoundException;
+import uk.gegc.quizmaker.model.attempt.Attempt;
+import uk.gegc.quizmaker.model.attempt.AttemptStatus;
+import uk.gegc.quizmaker.model.quiz.Quiz;
+import uk.gegc.quizmaker.model.user.User;
+import uk.gegc.quizmaker.service.attempt.AttemptService;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureWebMvc
+@ActiveProfiles("test")
+class AttemptControllerDeleteIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @MockitoBean
+    private AttemptService attemptService;
+
+    private MockMvc mockMvc;
+    private UUID attemptId;
+    private String username;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+
+        attemptId = UUID.randomUUID();
+        username = "testuser";
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/attempts/{attemptId}: successfully deletes attempt")
+    @WithMockUser(username = "testuser")
+    void deleteAttempt_success() throws Exception {
+        // Arrange
+        doNothing().when(attemptService).deleteAttempt(eq(username), eq(attemptId));
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/v1/attempts/{attemptId}", attemptId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+
+        verify(attemptService).deleteAttempt(username, attemptId);
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/attempts/{attemptId}: returns 404 when attempt not found")
+    @WithMockUser(username = "testuser")
+    void deleteAttempt_notFound_returns404() throws Exception {
+        // Arrange
+        doThrow(new ResourceNotFoundException("Attempt " + attemptId + " not found"))
+                .when(attemptService).deleteAttempt(eq(username), eq(attemptId));
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/v1/attempts/{attemptId}", attemptId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+
+        verify(attemptService).deleteAttempt(username, attemptId);
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/attempts/{attemptId}: returns 403 when user doesn't own the attempt")
+    @WithMockUser(username = "testuser")
+    void deleteAttempt_wrongUser_returns403() throws Exception {
+        // Arrange
+        doThrow(new org.springframework.security.access.AccessDeniedException("You do not have access to attempt " + attemptId))
+                .when(attemptService).deleteAttempt(eq(username), eq(attemptId));
+
+        // Act & Assert
+        mockMvc.perform(delete("/api/v1/attempts/{attemptId}", attemptId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+
+        verify(attemptService).deleteAttempt(username, attemptId);
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/attempts/{attemptId}: returns 403 when not authenticated")
+    void deleteAttempt_unauthenticated_returns403() throws Exception {
+        // Act & Assert
+        mockMvc.perform(delete("/api/v1/attempts/{attemptId}", attemptId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+
+        verify(attemptService, never()).deleteAttempt(any(), any());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/attempts/{attemptId}: returns 400 for invalid UUID format")
+    @WithMockUser(username = "testuser")
+    void deleteAttempt_invalidUuid_returns400() throws Exception {
+        // Act & Assert
+        mockMvc.perform(delete("/api/v1/attempts/{attemptId}", "invalid-uuid")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+        verify(attemptService, never()).deleteAttempt(any(), any());
+    }
+}

--- a/src/test/java/uk/gegc/quizmaker/service/attempt/AttemptServiceDeleteTest.java
+++ b/src/test/java/uk/gegc/quizmaker/service/attempt/AttemptServiceDeleteTest.java
@@ -1,0 +1,147 @@
+package uk.gegc.quizmaker.service.attempt;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gegc.quizmaker.exception.ResourceNotFoundException;
+import uk.gegc.quizmaker.model.attempt.Attempt;
+import uk.gegc.quizmaker.model.attempt.AttemptStatus;
+import uk.gegc.quizmaker.model.quiz.Quiz;
+import uk.gegc.quizmaker.model.user.User;
+import uk.gegc.quizmaker.repository.attempt.AttemptRepository;
+import uk.gegc.quizmaker.repository.question.AnswerRepository;
+import uk.gegc.quizmaker.service.attempt.impl.AttemptServiceImpl;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AttemptServiceDeleteTest {
+
+    @Mock
+    private AttemptRepository attemptRepository;
+
+    @Mock
+    private AnswerRepository answerRepository;
+
+    @InjectMocks
+    private AttemptServiceImpl attemptService;
+
+    private User testUser;
+    private Quiz testQuiz;
+    private Attempt testAttempt;
+    private UUID attemptId;
+    private String username;
+
+    @BeforeEach
+    void setUp() {
+        attemptId = UUID.randomUUID();
+        username = "testuser";
+
+        testUser = new User();
+        testUser.setId(UUID.randomUUID());
+        testUser.setUsername(username);
+
+        testQuiz = new Quiz();
+        testQuiz.setId(UUID.randomUUID());
+        testQuiz.setTitle("Test Quiz");
+
+        testAttempt = new Attempt();
+        testAttempt.setId(attemptId);
+        testAttempt.setUser(testUser);
+        testAttempt.setQuiz(testQuiz);
+        testAttempt.setStatus(AttemptStatus.IN_PROGRESS);
+        testAttempt.setStartedAt(Instant.now());
+    }
+
+    @Test
+    @DisplayName("deleteAttempt: successfully deletes attempt and its answers")
+    void deleteAttempt_success() {
+        // Arrange
+        when(attemptRepository.findById(attemptId)).thenReturn(Optional.of(testAttempt));
+        doNothing().when(answerRepository).deleteByAttemptId(attemptId);
+        doNothing().when(attemptRepository).delete(testAttempt);
+
+        // Act
+        assertDoesNotThrow(() -> attemptService.deleteAttempt(username, attemptId));
+
+        // Assert
+        verify(attemptRepository).findById(attemptId);
+        verify(answerRepository).deleteByAttemptId(attemptId);
+        verify(attemptRepository).delete(testAttempt);
+    }
+
+    @Test
+    @DisplayName("deleteAttempt: throws ResourceNotFoundException when attempt not found")
+    void deleteAttempt_notFound_throws404() {
+        // Arrange
+        when(attemptRepository.findById(attemptId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(ResourceNotFoundException.class, () ->
+                attemptService.deleteAttempt(username, attemptId));
+
+        verify(attemptRepository).findById(attemptId);
+        verify(answerRepository, never()).deleteByAttemptId(any());
+        verify(attemptRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("deleteAttempt: throws AccessDeniedException when user doesn't own the attempt")
+    void deleteAttempt_wrongUser_throws403() {
+        // Arrange
+        User differentUser = new User();
+        differentUser.setUsername("differentuser");
+        testAttempt.setUser(differentUser);
+
+        when(attemptRepository.findById(attemptId)).thenReturn(Optional.of(testAttempt));
+
+        // Act & Assert
+        assertThrows(org.springframework.security.access.AccessDeniedException.class, () ->
+                attemptService.deleteAttempt(username, attemptId));
+
+        verify(attemptRepository).findById(attemptId);
+        verify(answerRepository, never()).deleteByAttemptId(any());
+        verify(attemptRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("deleteAttempt: works with different attempt statuses")
+    void deleteAttempt_differentStatuses_success() {
+        // Test with different attempt statuses
+        AttemptStatus[] statuses = {
+                AttemptStatus.IN_PROGRESS,
+                AttemptStatus.COMPLETED,
+                AttemptStatus.PAUSED,
+                AttemptStatus.ABANDONED
+        };
+
+        for (AttemptStatus status : statuses) {
+            // Arrange
+            testAttempt.setStatus(status);
+            when(attemptRepository.findById(attemptId)).thenReturn(Optional.of(testAttempt));
+            doNothing().when(answerRepository).deleteByAttemptId(attemptId);
+            doNothing().when(attemptRepository).delete(testAttempt);
+
+            // Act & Assert
+            assertDoesNotThrow(() -> attemptService.deleteAttempt(username, attemptId));
+
+            // Verify
+            verify(attemptRepository).findById(attemptId);
+            verify(answerRepository).deleteByAttemptId(attemptId);
+            verify(attemptRepository).delete(testAttempt);
+
+            // Reset mocks for next iteration
+            reset(attemptRepository, answerRepository);
+        }
+    }
+}


### PR DESCRIPTION
- Implemented a new endpoint in AttemptController to allow users to delete their own quiz attempts along with associated answers.
- Enhanced AttemptService with a method to handle the deletion logic, ensuring ownership validation and cascading deletion of answers.
- Updated AnswerRepository to include a method for deleting answers by attempt ID, supporting the new deletion feature.
- Added API documentation for the delete attempt endpoint, improving clarity for users and developers.