### PR TITLE
Refactor moderation logic to use moderator username instead of ID

### DIFF
--- a/src/main/java/uk/gegc/quizmaker/features/quiz/api/ModerationController.java
+++ b/src/main/java/uk/gegc/quizmaker/features/quiz/api/ModerationController.java
@@ -1,7 +1,7 @@
 package uk.gegc.quizmaker.features.quiz.api;
 
-import jakarta.validation.constraints.NotNull;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import uk.gegc.quizmaker.features.user.domain.model.PermissionName;
 import uk.gegc.quizmaker.shared.security.annotation.RequirePermission;
 import org.springframework.web.bind.annotation.*;
@@ -25,27 +25,27 @@ public class ModerationController {
     @PostMapping("/{quizId}/approve")
     @RequirePermission(PermissionName.QUIZ_MODERATE)
     public ResponseEntity<Void> approveQuiz(@PathVariable UUID quizId,
-                                            @RequestParam @NotNull UUID moderatorId,
-                                            @RequestParam(required = false) String reason) {
-        moderationService.approveQuiz(quizId, moderatorId, reason);
+                                            @RequestParam(required = false) String reason,
+                                            Authentication authentication) {
+        moderationService.approveQuiz(quizId, authentication.getName(), reason);
         return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/{quizId}/reject")
     @RequirePermission(PermissionName.QUIZ_MODERATE)
     public ResponseEntity<Void> rejectQuiz(@PathVariable UUID quizId,
-                                           @RequestParam @NotNull UUID moderatorId,
-                                           @RequestParam String reason) {
-        moderationService.rejectQuiz(quizId, moderatorId, reason);
+                                           @RequestParam String reason,
+                                           Authentication authentication) {
+        moderationService.rejectQuiz(quizId, authentication.getName(), reason);
         return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/{quizId}/unpublish")
     @RequirePermission(PermissionName.QUIZ_MODERATE)
     public ResponseEntity<Void> unpublishQuiz(@PathVariable UUID quizId,
-                                              @RequestParam @NotNull UUID moderatorId,
-                                              @RequestParam(required = false) String reason) {
-        moderationService.unpublishQuiz(quizId, moderatorId, reason);
+                                              @RequestParam(required = false) String reason,
+                                              Authentication authentication) {
+        moderationService.unpublishQuiz(quizId, authentication.getName(), reason);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/uk/gegc/quizmaker/features/quiz/api/QuizController.java
+++ b/src/main/java/uk/gegc/quizmaker/features/quiz/api/QuizController.java
@@ -365,7 +365,7 @@ public class QuizController {
 
     @Operation(
             summary = "Toggle quiz visibility",
-            description = "Switch a quiz between PUBLIC and PRIVATE. Requires QUIZ_MODERATE or QUIZ_ADMIN permissions.",
+            description = "Switch a quiz between PUBLIC and PRIVATE. Owners can set PRIVATE; PUBLIC requires QUIZ_MODERATE or QUIZ_ADMIN permissions.",
             security = @SecurityRequirement(name = "bearerAuth"),
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,
@@ -392,7 +392,7 @@ public class QuizController {
                     ),
                     @ApiResponse(
                             responseCode = "403",
-                            description = "Authenticated but not an ADMIN",
+                            description = "Forbidden – owner trying to set PUBLIC or non-owner/non-moderator trying to change visibility",
                             content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))
                     ),
                     @ApiResponse(
@@ -403,7 +403,7 @@ public class QuizController {
             }
     )
     @PatchMapping("/{quizId}/visibility")
-    @RequirePermission(value = {PermissionName.QUIZ_MODERATE, PermissionName.QUIZ_ADMIN}, operator = RequirePermission.LogicalOperator.OR)
+    @RequirePermission(value = {PermissionName.QUIZ_UPDATE, PermissionName.QUIZ_MODERATE, PermissionName.QUIZ_ADMIN}, operator = RequirePermission.LogicalOperator.OR)
     public ResponseEntity<QuizDto> updateQuizVisibility(
             @Parameter(description = "UUID of the quiz to update", required = true)
             @PathVariable UUID quizId,
@@ -420,7 +420,7 @@ public class QuizController {
 
     @Operation(
             summary = "Change quiz status",
-            description = "Switch a quiz between DRAFT and PUBLISHED. Requires QUIZ_MODERATE or QUIZ_ADMIN permissions.",
+            description = "Switch a quiz status. Owners can publish privately (PRIVATE visibility) and unpublish to DRAFT. Publishing a PUBLIC quiz requires QUIZ_MODERATE or QUIZ_ADMIN permissions.",
             security = @SecurityRequirement(name = "bearerAuth"),
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,
@@ -433,14 +433,14 @@ public class QuizController {
                             content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
                     @ApiResponse(responseCode = "401", description = "Unauthenticated",
                             content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
-                    @ApiResponse(responseCode = "403", description = "Authenticated but not ADMIN",
+                    @ApiResponse(responseCode = "403", description = "Forbidden – owner trying to publish PUBLIC quiz or non-owner/non-moderator trying to change status",
                             content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class))),
                     @ApiResponse(responseCode = "404", description = "Quiz not found",
                             content = @Content(schema = @Schema(implementation = GlobalExceptionHandler.ErrorResponse.class)))
             }
     )
     @PatchMapping("/{quizId}/status")
-    @RequirePermission(value = {PermissionName.QUIZ_MODERATE, PermissionName.QUIZ_ADMIN}, operator = RequirePermission.LogicalOperator.OR)
+    @RequirePermission(value = {PermissionName.QUIZ_UPDATE, PermissionName.QUIZ_MODERATE, PermissionName.QUIZ_ADMIN}, operator = RequirePermission.LogicalOperator.OR)
     public ResponseEntity<QuizDto> updateQuizStatus(
             @Parameter(description = "UUID of the quiz to update", required = true)
             @PathVariable UUID quizId,

--- a/src/main/java/uk/gegc/quizmaker/features/quiz/application/ModerationService.java
+++ b/src/main/java/uk/gegc/quizmaker/features/quiz/application/ModerationService.java
@@ -8,9 +8,9 @@ import java.util.UUID;
 
 public interface ModerationService {
     void submitForReview(UUID quizId, UUID userId);
-    void approveQuiz(UUID quizId, UUID moderatorId, String reason);
-    void rejectQuiz(UUID quizId, UUID moderatorId, String reason);
-    void unpublishQuiz(UUID quizId, UUID moderatorId, String reason);
+    void approveQuiz(UUID quizId, String moderatorUsername, String reason);
+    void rejectQuiz(UUID quizId, String moderatorUsername, String reason);
+    void unpublishQuiz(UUID quizId, String moderatorUsername, String reason);
     List<PendingReviewQuizDto> getPendingReviewQuizzes(UUID orgId);
     List<QuizModerationAuditDto> getQuizAuditTrail(UUID quizId);
 }

--- a/src/main/java/uk/gegc/quizmaker/features/quiz/application/impl/ModerationServiceImpl.java
+++ b/src/main/java/uk/gegc/quizmaker/features/quiz/application/impl/ModerationServiceImpl.java
@@ -75,12 +75,13 @@ public class ModerationServiceImpl implements ModerationService {
 
     @Override
     @Transactional
-    public void approveQuiz(UUID quizId, UUID moderatorId, String reason) {
+    public void approveQuiz(UUID quizId, String moderatorUsername, String reason) {
         Quiz quiz = quizRepository.findById(quizId)
                 .orElseThrow(() -> new ResourceNotFoundException("Quiz " + quizId + " not found"));
 
-        User moderator = userRepository.findById(moderatorId)
-                .orElseThrow(() -> new ResourceNotFoundException("User " + moderatorId + " not found"));
+        User moderator = userRepository.findByUsername(moderatorUsername)
+                .or(() -> userRepository.findByEmail(moderatorUsername))
+                .orElseThrow(() -> new ResourceNotFoundException("User " + moderatorUsername + " not found"));
 
         // Only PENDING_REVIEW can move to PUBLISHED
         if (quiz.getStatus() != QuizStatus.PENDING_REVIEW) {
@@ -109,12 +110,13 @@ public class ModerationServiceImpl implements ModerationService {
 
     @Override
     @Transactional
-    public void rejectQuiz(UUID quizId, UUID moderatorId, String reason) {
+    public void rejectQuiz(UUID quizId, String moderatorUsername, String reason) {
         Quiz quiz = quizRepository.findById(quizId)
                 .orElseThrow(() -> new ResourceNotFoundException("Quiz " + quizId + " not found"));
 
-        User moderator = userRepository.findById(moderatorId)
-                .orElseThrow(() -> new ResourceNotFoundException("User " + moderatorId + " not found"));
+        User moderator = userRepository.findByUsername(moderatorUsername)
+                .or(() -> userRepository.findByEmail(moderatorUsername))
+                .orElseThrow(() -> new ResourceNotFoundException("User " + moderatorUsername + " not found"));
 
         // Only PENDING_REVIEW can move to REJECTED
         if (quiz.getStatus() != QuizStatus.PENDING_REVIEW) {
@@ -140,12 +142,13 @@ public class ModerationServiceImpl implements ModerationService {
 
     @Override
     @Transactional
-    public void unpublishQuiz(UUID quizId, UUID moderatorId, String reason) {
+    public void unpublishQuiz(UUID quizId, String moderatorUsername, String reason) {
         Quiz quiz = quizRepository.findById(quizId)
                 .orElseThrow(() -> new ResourceNotFoundException("Quiz " + quizId + " not found"));
 
-        User moderator = userRepository.findById(moderatorId)
-                .orElseThrow(() -> new ResourceNotFoundException("User " + moderatorId + " not found"));
+        User moderator = userRepository.findByUsername(moderatorUsername)
+                .or(() -> userRepository.findByEmail(moderatorUsername))
+                .orElseThrow(() -> new ResourceNotFoundException("User " + moderatorUsername + " not found"));
 
         // Only PUBLISHED can move to DRAFT via unpublish per plan
         if (quiz.getStatus() != QuizStatus.PUBLISHED) {

--- a/src/main/java/uk/gegc/quizmaker/features/quiz/application/impl/QuizServiceImpl.java
+++ b/src/main/java/uk/gegc/quizmaker/features/quiz/application/impl/QuizServiceImpl.java
@@ -1127,9 +1127,13 @@ public class QuizServiceImpl implements QuizService {
             throw new ForbiddenException("Not allowed to change quiz status");
         }
         
-        // Additional restriction: only moderators/admins can set status to PUBLISHED
+        // Refined publishing rules: owners can publish PRIVATE quizzes, but PUBLIC requires moderation
         if (status == QuizStatus.PUBLISHED && !hasModerationPermissions) {
-            throw new ForbiddenException("Only moderators can publish quizzes");
+            // Owners can only publish when visibility is PRIVATE
+            if (quiz.getVisibility() == Visibility.PUBLIC) {
+                throw new ForbiddenException("Only moderators can publish PUBLIC quizzes. Set visibility to PRIVATE first or submit for moderation.");
+            }
+            // Owner publishing privately - allowed
         }
 
         if (status == QuizStatus.PUBLISHED) {

--- a/src/test/java/uk/gegc/quizmaker/features/quiz/application/impl/ModerationAuditIntegrityTest.java
+++ b/src/test/java/uk/gegc/quizmaker/features/quiz/application/impl/ModerationAuditIntegrityTest.java
@@ -1,0 +1,202 @@
+package uk.gegc.quizmaker.features.quiz.application.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gegc.quizmaker.features.quiz.domain.model.*;
+import uk.gegc.quizmaker.features.quiz.domain.repository.QuizModerationAuditRepository;
+import uk.gegc.quizmaker.features.quiz.domain.repository.QuizRepository;
+import uk.gegc.quizmaker.features.quiz.infra.mapping.QuizMapper;
+import uk.gegc.quizmaker.features.user.domain.model.User;
+import uk.gegc.quizmaker.features.user.domain.repository.UserRepository;
+import uk.gegc.quizmaker.shared.security.AppPermissionEvaluator;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for Moderation Audit Integrity
+ * 
+ * Validates that moderation actions correctly derive the moderator identity
+ * from the authenticated user (via username) instead of accepting a forged
+ * moderatorId from the request parameter.
+ * 
+ * This prevents security vulnerabilities where an attacker could submit
+ * a different moderator ID to spoof their identity in audit logs.
+ */
+@ExtendWith(MockitoExtension.class)
+@org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+@Execution(ExecutionMode.CONCURRENT)
+@DisplayName("Moderation Audit Integrity Tests")
+class ModerationAuditIntegrityTest {
+
+    @Mock
+    private QuizRepository quizRepository;
+    
+    @Mock
+    private UserRepository userRepository;
+    
+    @Mock
+    private QuizMapper quizMapper;
+    
+    @Mock
+    private QuizModerationAuditRepository auditRepository;
+    
+    @Mock
+    private AppPermissionEvaluator appPermissionEvaluator;
+
+    @InjectMocks
+    private ModerationServiceImpl moderationService;
+
+    private User authenticatedModerator;
+    private Quiz testQuiz;
+
+    @BeforeEach
+    void setUp() {
+        // Given: Create a moderator and a quiz
+        authenticatedModerator = createModerator("moderator1", "moderator1@example.com");
+        testQuiz = createQuizPendingReview();
+        
+        setupUserRepositoryMock();
+    }
+
+    @Test
+    @DisplayName("approveQuiz: derives moderator from username not request parameter")
+    void approveQuiz_derivesModerator_fromUsername() {
+        // Given
+        when(quizRepository.findById(testQuiz.getId())).thenReturn(Optional.of(testQuiz));
+        when(quizRepository.saveAndFlush(any(Quiz.class))).thenReturn(testQuiz);
+        
+        ArgumentCaptor<QuizModerationAudit> auditCaptor = ArgumentCaptor.forClass(QuizModerationAudit.class);
+
+        // When: Approve quiz using the authenticated moderator's username
+        moderationService.approveQuiz(testQuiz.getId(), authenticatedModerator.getUsername(), "Looks good");
+
+        // Then: The audit record should reference the correct moderator
+        verify(auditRepository).save(auditCaptor.capture());
+        QuizModerationAudit audit = auditCaptor.getValue();
+        
+        assertThat(audit.getModerator()).isNotNull();
+        assertThat(audit.getModerator().getId()).isEqualTo(authenticatedModerator.getId());
+        assertThat(audit.getModerator().getUsername()).isEqualTo(authenticatedModerator.getUsername());
+        assertThat(audit.getAction()).isEqualTo(ModerationAction.APPROVE);
+        assertThat(audit.getReason()).isEqualTo("Looks good");
+    }
+
+    @Test
+    @DisplayName("rejectQuiz: derives moderator from username not request parameter")
+    void rejectQuiz_derivesModerator_fromUsername() {
+        // Given
+        when(quizRepository.findById(testQuiz.getId())).thenReturn(Optional.of(testQuiz));
+        when(quizRepository.saveAndFlush(any(Quiz.class))).thenReturn(testQuiz);
+        
+        ArgumentCaptor<QuizModerationAudit> auditCaptor = ArgumentCaptor.forClass(QuizModerationAudit.class);
+
+        // When: Reject quiz using the authenticated moderator's username
+        moderationService.rejectQuiz(testQuiz.getId(), authenticatedModerator.getUsername(), "Inappropriate content");
+
+        // Then: The audit record should reference the correct moderator
+        verify(auditRepository).save(auditCaptor.capture());
+        QuizModerationAudit audit = auditCaptor.getValue();
+        
+        assertThat(audit.getModerator()).isNotNull();
+        assertThat(audit.getModerator().getId()).isEqualTo(authenticatedModerator.getId());
+        assertThat(audit.getModerator().getUsername()).isEqualTo(authenticatedModerator.getUsername());
+        assertThat(audit.getAction()).isEqualTo(ModerationAction.REJECT);
+        assertThat(audit.getReason()).isEqualTo("Inappropriate content");
+    }
+
+    @Test
+    @DisplayName("unpublishQuiz: derives moderator from username not request parameter")
+    void unpublishQuiz_derivesModerator_fromUsername() {
+        // Given
+        testQuiz.setStatus(QuizStatus.PUBLISHED);
+        when(quizRepository.findById(testQuiz.getId())).thenReturn(Optional.of(testQuiz));
+        when(quizRepository.saveAndFlush(any(Quiz.class))).thenReturn(testQuiz);
+        
+        ArgumentCaptor<QuizModerationAudit> auditCaptor = ArgumentCaptor.forClass(QuizModerationAudit.class);
+
+        // When: Unpublish quiz using the authenticated moderator's username
+        moderationService.unpublishQuiz(testQuiz.getId(), authenticatedModerator.getUsername(), "Policy violation");
+
+        // Then: The audit record should reference the correct moderator
+        verify(auditRepository).save(auditCaptor.capture());
+        QuizModerationAudit audit = auditCaptor.getValue();
+        
+        assertThat(audit.getModerator()).isNotNull();
+        assertThat(audit.getModerator().getId()).isEqualTo(authenticatedModerator.getId());
+        assertThat(audit.getModerator().getUsername()).isEqualTo(authenticatedModerator.getUsername());
+        assertThat(audit.getAction()).isEqualTo(ModerationAction.UNPUBLISH);
+        assertThat(audit.getReason()).isEqualTo("Policy violation");
+    }
+
+    @Test
+    @DisplayName("approveQuiz: supports lookup by email as well as username")
+    void approveQuiz_supportsEmail_lookupFallback() {
+        // Given
+        when(quizRepository.findById(testQuiz.getId())).thenReturn(Optional.of(testQuiz));
+        when(quizRepository.saveAndFlush(any(Quiz.class))).thenReturn(testQuiz);
+        
+        // When username is not found, should try email
+        when(userRepository.findByUsername(authenticatedModerator.getEmail()))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmail(authenticatedModerator.getEmail()))
+                .thenReturn(Optional.of(authenticatedModerator));
+        
+        ArgumentCaptor<QuizModerationAudit> auditCaptor = ArgumentCaptor.forClass(QuizModerationAudit.class);
+
+        // When: Approve using email as identifier
+        moderationService.approveQuiz(testQuiz.getId(), authenticatedModerator.getEmail(), "Approved via email lookup");
+
+        // Then: Should still correctly resolve the moderator
+        verify(auditRepository).save(auditCaptor.capture());
+        QuizModerationAudit audit = auditCaptor.getValue();
+        
+        assertThat(audit.getModerator()).isNotNull();
+        assertThat(audit.getModerator().getId()).isEqualTo(authenticatedModerator.getId());
+    }
+
+    // =============== Helper Methods ===============
+
+    private User createModerator(String username, String email) {
+        User user = new User();
+        user.setId(UUID.randomUUID());
+        user.setUsername(username);
+        user.setEmail(email);
+        user.setActive(true);
+        user.setDeleted(false);
+        user.setEmailVerified(true);
+        return user;
+    }
+
+    private Quiz createQuizPendingReview() {
+        Quiz quiz = new Quiz();
+        quiz.setId(UUID.randomUUID());
+        quiz.setTitle("Test Quiz Pending Review");
+        quiz.setDescription("Test Description");
+        quiz.setStatus(QuizStatus.PENDING_REVIEW);
+        quiz.setVisibility(Visibility.PRIVATE);
+        quiz.setLockedForReview(true);
+        return quiz;
+    }
+
+    private void setupUserRepositoryMock() {
+        when(userRepository.findByUsername(authenticatedModerator.getUsername()))
+                .thenReturn(Optional.of(authenticatedModerator));
+        when(userRepository.findByEmail(authenticatedModerator.getEmail()))
+                .thenReturn(Optional.of(authenticatedModerator));
+    }
+}
+

--- a/src/test/java/uk/gegc/quizmaker/features/quiz/application/impl/QuizOwnerPrivatePublishTest.java
+++ b/src/test/java/uk/gegc/quizmaker/features/quiz/application/impl/QuizOwnerPrivatePublishTest.java
@@ -1,0 +1,368 @@
+package uk.gegc.quizmaker.features.quiz.application.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.support.TransactionTemplate;
+import uk.gegc.quizmaker.features.ai.application.AiQuizGenerationService;
+import uk.gegc.quizmaker.features.billing.application.BillingService;
+import uk.gegc.quizmaker.features.billing.application.EstimationService;
+import uk.gegc.quizmaker.features.billing.application.InternalBillingService;
+import uk.gegc.quizmaker.features.category.domain.repository.CategoryRepository;
+import uk.gegc.quizmaker.features.document.application.DocumentProcessingService;
+import uk.gegc.quizmaker.features.question.domain.model.Difficulty;
+import uk.gegc.quizmaker.features.question.domain.model.Question;
+import uk.gegc.quizmaker.features.question.domain.model.QuestionType;
+import uk.gegc.quizmaker.features.question.domain.repository.QuestionRepository;
+import uk.gegc.quizmaker.features.question.infra.factory.QuestionHandlerFactory;
+import uk.gegc.quizmaker.features.question.infra.handler.QuestionHandler;
+import uk.gegc.quizmaker.features.quiz.api.dto.QuizDto;
+import uk.gegc.quizmaker.features.quiz.application.QuizGenerationJobService;
+import uk.gegc.quizmaker.features.quiz.application.QuizHashCalculator;
+import uk.gegc.quizmaker.features.quiz.domain.model.Quiz;
+import uk.gegc.quizmaker.features.quiz.domain.model.QuizStatus;
+import uk.gegc.quizmaker.features.quiz.domain.model.Visibility;
+import uk.gegc.quizmaker.features.quiz.domain.repository.QuizGenerationJobRepository;
+import uk.gegc.quizmaker.features.quiz.domain.repository.QuizRepository;
+import uk.gegc.quizmaker.features.quiz.infra.mapping.QuizMapper;
+import uk.gegc.quizmaker.features.tag.domain.repository.TagRepository;
+import uk.gegc.quizmaker.features.user.domain.model.PermissionName;
+import uk.gegc.quizmaker.features.user.domain.model.Role;
+import uk.gegc.quizmaker.features.user.domain.model.User;
+import uk.gegc.quizmaker.features.user.domain.repository.UserRepository;
+import uk.gegc.quizmaker.shared.config.FeatureFlags;
+import uk.gegc.quizmaker.shared.exception.ForbiddenException;
+import uk.gegc.quizmaker.shared.security.AppPermissionEvaluator;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for Quiz Flow Refactor: Owner Freedom, Public Safety
+ * 
+ * These tests validate that:
+ * 1. Owners can publish their own quizzes when visibility is PRIVATE
+ * 2. Owners cannot publish PUBLIC quizzes (requires moderation)
+ * 3. Owners can unpublish their quizzes (set status to DRAFT)
+ * 4. Owners can set visibility to PRIVATE
+ * 5. Owners cannot set visibility to PUBLIC (requires moderation)
+ */
+@ExtendWith(MockitoExtension.class)
+@org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+@Execution(ExecutionMode.CONCURRENT)
+@DisplayName("Quiz Owner Private Publish Tests")
+class QuizOwnerPrivatePublishTest {
+
+    @Mock private QuizRepository quizRepository;
+    @Mock private QuestionRepository questionRepository;
+    @Mock private TagRepository tagRepository;
+    @Mock private CategoryRepository categoryRepository;
+    @Mock private QuizMapper quizMapper;
+    @Mock private UserRepository userRepository;
+    @Mock private QuestionHandlerFactory questionHandlerFactory;
+    @Mock private QuestionHandler questionHandler;
+    @Mock private QuizGenerationJobRepository jobRepository;
+    @Mock private QuizGenerationJobService jobService;
+    @Mock private AiQuizGenerationService aiQuizGenerationService;
+    @Mock private DocumentProcessingService documentProcessingService;
+    @Mock private QuizHashCalculator quizHashCalculator;
+    @Mock private BillingService billingService;
+    @Mock private InternalBillingService internalBillingService;
+    @Mock private EstimationService estimationService;
+    @Mock private FeatureFlags featureFlags;
+    @Mock private AppPermissionEvaluator appPermissionEvaluator;
+    @Mock private TransactionTemplate transactionTemplate;
+    @Mock private ApplicationEventPublisher applicationEventPublisher;
+
+    @InjectMocks
+    private QuizServiceImpl quizService;
+
+    private User ownerUser;
+    private User moderatorUser;
+    private Quiz testQuiz;
+    private QuizDto testQuizDto;
+
+    @BeforeEach
+    void setUp() {
+        // Given: Create an owner user
+        ownerUser = createOwnerUser();
+        moderatorUser = createModeratorUser();
+        testQuiz = createValidQuiz(ownerUser);
+        testQuizDto = createQuizDto(testQuiz.getId(), QuizStatus.PUBLISHED, Visibility.PRIVATE);
+        
+        setupUserRepositoryMock();
+        setupPermissionEvaluatorMock();
+    }
+
+    // =============== setStatus Tests ===============
+
+    @Test
+    @DisplayName("setStatus: when owner sets PUBLISHED on PRIVATE quiz then succeeds")
+    void setStatus_ownerPublishPrivate_succeeds() {
+        // Given
+        testQuiz.setVisibility(Visibility.PRIVATE);
+        testQuiz.setStatus(QuizStatus.DRAFT);
+        
+        when(quizRepository.findByIdWithQuestions(testQuiz.getId()))
+                .thenReturn(Optional.of(testQuiz));
+        when(quizRepository.save(any(Quiz.class))).thenReturn(testQuiz);
+        when(quizMapper.toDto(any(Quiz.class))).thenReturn(testQuizDto);
+        // Mock question validation
+        when(questionHandlerFactory.getHandler(any(QuestionType.class))).thenReturn(questionHandler);
+
+        // When
+        QuizDto result = quizService.setStatus(ownerUser.getUsername(), testQuiz.getId(), QuizStatus.PUBLISHED);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(testQuiz.getStatus()).isEqualTo(QuizStatus.PUBLISHED);
+        verify(quizRepository).save(testQuiz);
+    }
+
+    @Test
+    @DisplayName("setStatus: when owner sets PUBLISHED on PUBLIC quiz then forbidden")
+    void setStatus_ownerPublishPublic_forbidden() {
+        // Given
+        testQuiz.setVisibility(Visibility.PUBLIC);
+        testQuiz.setStatus(QuizStatus.DRAFT);
+        
+        when(quizRepository.findByIdWithQuestions(testQuiz.getId()))
+                .thenReturn(Optional.of(testQuiz));
+
+        // When/Then
+        assertThatThrownBy(() -> quizService.setStatus(ownerUser.getUsername(), testQuiz.getId(), QuizStatus.PUBLISHED))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("Only moderators can publish PUBLIC quizzes");
+        
+        verify(quizRepository, never()).save(any(Quiz.class));
+    }
+
+    @Test
+    @DisplayName("setStatus: when owner sets DRAFT from PUBLISHED then succeeds (unpublish)")
+    void setStatus_ownerUnpublish_succeeds() {
+        // Given
+        testQuiz.setVisibility(Visibility.PUBLIC);
+        testQuiz.setStatus(QuizStatus.PUBLISHED);
+        QuizDto draftDto = createQuizDto(testQuiz.getId(), QuizStatus.DRAFT, Visibility.PUBLIC);
+        
+        when(quizRepository.findByIdWithQuestions(testQuiz.getId()))
+                .thenReturn(Optional.of(testQuiz));
+        when(quizRepository.save(any(Quiz.class))).thenReturn(testQuiz);
+        when(quizMapper.toDto(any(Quiz.class))).thenReturn(draftDto);
+
+        // When
+        QuizDto result = quizService.setStatus(ownerUser.getUsername(), testQuiz.getId(), QuizStatus.DRAFT);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(testQuiz.getStatus()).isEqualTo(QuizStatus.DRAFT);
+        verify(quizRepository).save(testQuiz);
+    }
+
+    @Test
+    @DisplayName("setStatus: when moderator sets PUBLISHED on PUBLIC quiz then succeeds")
+    void setStatus_moderatorPublishPublic_succeeds() {
+        // Given
+        testQuiz.setVisibility(Visibility.PUBLIC);
+        testQuiz.setStatus(QuizStatus.DRAFT);
+        QuizDto publicDto = createQuizDto(testQuiz.getId(), QuizStatus.PUBLISHED, Visibility.PUBLIC);
+        
+        when(quizRepository.findByIdWithQuestions(testQuiz.getId()))
+                .thenReturn(Optional.of(testQuiz));
+        when(quizRepository.save(any(Quiz.class))).thenReturn(testQuiz);
+        when(quizMapper.toDto(any(Quiz.class))).thenReturn(publicDto);
+        // Mock question validation
+        when(questionHandlerFactory.getHandler(any(QuestionType.class))).thenReturn(questionHandler);
+
+        // When
+        QuizDto result = quizService.setStatus(moderatorUser.getUsername(), testQuiz.getId(), QuizStatus.PUBLISHED);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(testQuiz.getStatus()).isEqualTo(QuizStatus.PUBLISHED);
+        verify(quizRepository).save(testQuiz);
+    }
+
+    // =============== setVisibility Tests ===============
+
+    @Test
+    @DisplayName("setVisibility: when owner sets PRIVATE then succeeds")
+    void setVisibility_ownerSetPrivate_succeeds() {
+        // Given
+        testQuiz.setVisibility(Visibility.PUBLIC);
+        QuizDto privateDto = createQuizDto(testQuiz.getId(), QuizStatus.PUBLISHED, Visibility.PRIVATE);
+        
+        when(quizRepository.findById(testQuiz.getId()))
+                .thenReturn(Optional.of(testQuiz));
+        when(quizRepository.save(any(Quiz.class))).thenReturn(testQuiz);
+        when(quizMapper.toDto(any(Quiz.class))).thenReturn(privateDto);
+
+        // When
+        QuizDto result = quizService.setVisibility(ownerUser.getUsername(), testQuiz.getId(), Visibility.PRIVATE);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(testQuiz.getVisibility()).isEqualTo(Visibility.PRIVATE);
+        verify(quizRepository).save(testQuiz);
+    }
+
+    @Test
+    @DisplayName("setVisibility: when owner sets PUBLIC then forbidden")
+    void setVisibility_ownerSetPublic_forbidden() {
+        // Given
+        testQuiz.setVisibility(Visibility.PRIVATE);
+        
+        when(quizRepository.findById(testQuiz.getId()))
+                .thenReturn(Optional.of(testQuiz));
+
+        // When/Then
+        assertThatThrownBy(() -> quizService.setVisibility(ownerUser.getUsername(), testQuiz.getId(), Visibility.PUBLIC))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("Only moderators can set quiz visibility to PUBLIC");
+        
+        verify(quizRepository, never()).save(any(Quiz.class));
+    }
+
+    @Test
+    @DisplayName("setVisibility: when moderator sets PUBLIC then succeeds")
+    void setVisibility_moderatorSetPublic_succeeds() {
+        // Given
+        testQuiz.setVisibility(Visibility.PRIVATE);
+        QuizDto publicDto = createQuizDto(testQuiz.getId(), QuizStatus.PUBLISHED, Visibility.PUBLIC);
+        
+        when(quizRepository.findById(testQuiz.getId()))
+                .thenReturn(Optional.of(testQuiz));
+        when(quizRepository.save(any(Quiz.class))).thenReturn(testQuiz);
+        when(quizMapper.toDto(any(Quiz.class))).thenReturn(publicDto);
+
+        // When
+        QuizDto result = quizService.setVisibility(moderatorUser.getUsername(), testQuiz.getId(), Visibility.PUBLIC);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(testQuiz.getVisibility()).isEqualTo(Visibility.PUBLIC);
+        verify(quizRepository).save(testQuiz);
+    }
+
+    // =============== Helper Methods ===============
+
+    private User createOwnerUser() {
+        User user = new User();
+        user.setId(UUID.randomUUID());
+        user.setUsername("owner");
+        user.setEmail("owner@example.com");
+        user.setActive(true);
+        user.setDeleted(false);
+        user.setEmailVerified(true);
+        
+        Role role = new Role();
+        role.setRoleId(1L);
+        role.setRoleName("ROLE_USER");
+        role.setDescription("Regular user role");
+        
+        user.setRoles(new HashSet<>(Set.of(role)));
+        return user;
+    }
+
+    private User createModeratorUser() {
+        User user = new User();
+        user.setId(UUID.randomUUID());
+        user.setUsername("moderator");
+        user.setEmail("moderator@example.com");
+        user.setActive(true);
+        user.setDeleted(false);
+        user.setEmailVerified(true);
+        
+        Role role = new Role();
+        role.setRoleId(2L);
+        role.setRoleName("ROLE_MODERATOR");
+        role.setDescription("Moderator role");
+        
+        user.setRoles(new HashSet<>(Set.of(role)));
+        return user;
+    }
+
+    private Quiz createValidQuiz(User creator) {
+        Quiz quiz = new Quiz();
+        quiz.setId(UUID.randomUUID());
+        quiz.setTitle("Test Quiz");
+        quiz.setDescription("Test Description");
+        quiz.setCreator(creator);
+        quiz.setStatus(QuizStatus.DRAFT);
+        quiz.setVisibility(Visibility.PRIVATE);
+        quiz.setEstimatedTime(10);
+        
+        // Add a valid question
+        Question question = new Question();
+        question.setId(UUID.randomUUID());
+        question.setQuestionText("What is 2+2?");
+        question.setType(QuestionType.MCQ_SINGLE);
+        question.setDifficulty(Difficulty.EASY);
+        question.setContent("{\"options\":[{\"id\":\"a\",\"text\":\"4\",\"isCorrect\":true}]}");
+        
+        quiz.setQuestions(new HashSet<>(Set.of(question)));
+        return quiz;
+    }
+    
+    private QuizDto createQuizDto(UUID id, QuizStatus status, Visibility visibility) {
+        return new QuizDto(
+                id,
+                UUID.randomUUID(), // creatorId
+                UUID.randomUUID(), // categoryId
+                "Test Quiz",
+                "Test Description",
+                visibility,
+                Difficulty.MEDIUM,
+                status,
+                10, // estimatedTime
+                false, // isRepetitionEnabled
+                false, // timerEnabled
+                null, // timerDuration
+                java.util.List.of(), // tagIds
+                java.time.Instant.now(), // createdAt
+                java.time.Instant.now() // updatedAt
+        );
+    }
+
+    private void setupUserRepositoryMock() {
+        when(userRepository.findByUsername(ownerUser.getUsername()))
+                .thenReturn(Optional.of(ownerUser));
+        when(userRepository.findByEmail(ownerUser.getEmail()))
+                .thenReturn(Optional.of(ownerUser));
+        
+        when(userRepository.findByUsername(moderatorUser.getUsername()))
+                .thenReturn(Optional.of(moderatorUser));
+        when(userRepository.findByEmail(moderatorUser.getEmail()))
+                .thenReturn(Optional.of(moderatorUser));
+    }
+
+    private void setupPermissionEvaluatorMock() {
+        // Owner does not have moderation permissions
+        when(appPermissionEvaluator.hasPermission(eq(ownerUser), eq(PermissionName.QUIZ_MODERATE)))
+                .thenReturn(false);
+        when(appPermissionEvaluator.hasPermission(eq(ownerUser), eq(PermissionName.QUIZ_ADMIN)))
+                .thenReturn(false);
+        
+        // Moderator has moderation permissions
+        when(appPermissionEvaluator.hasPermission(eq(moderatorUser), eq(PermissionName.QUIZ_MODERATE)))
+                .thenReturn(true);
+        when(appPermissionEvaluator.hasPermission(eq(moderatorUser), eq(PermissionName.QUIZ_ADMIN)))
+                .thenReturn(false);
+    }
+}
+


### PR DESCRIPTION
This commit updates the ModerationController, ModerationService, and their implementations to accept the moderator's username for approving, rejecting, and unpublishing quizzes. The changes enhance the moderation process by allowing the use of usernames, improving flexibility and usability. Additionally, the QuizController's permission requirements are refined to include QUIZ_UPDATE for visibility and status updates, ensuring clearer permission handling. Relevant tests are also updated to reflect these changes.