### PR TITLE
Update API documentation configuration in application-prod.properties…

### DIFF
--- a/server/backend/application-prod.properties
+++ b/server/backend/application-prod.properties
@@ -164,11 +164,6 @@ quizmaker.document.chunking.prompt-overhead-tokens=15000
 quizmaker.document.chunking.aggressive-chunking=true
 quizmaker.document.chunking.enable-emergency-chunking=true
 
-# API Documentation
-springdoc.api-docs.path=/api/v1/docs
-springdoc.swagger-ui.path=/api/v1/docs/swagger-ui.html
-springdoc.swagger-ui.url=/api/v1/docs
-
 # Actuator Configuration
 management.endpoints.web.exposure.include=health,info,metrics
 management.endpoint.health.show-details=always


### PR DESCRIPTION
… to use SpringDoc defaults. Added comments for clarity on the custom landing page and default paths for API documentation endpoints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove custom SpringDoc API docs/Swagger UI paths in prod config to use defaults.
> 
> - **Config (prod)**: Remove custom SpringDoc API docs/Swagger UI paths from `server/backend/application-prod.properties` to rely on defaults (`springdoc.api-docs.path`, `springdoc.swagger-ui.path`, `springdoc.swagger-ui.url`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a415a116842393696ab71f7fb1ced8eff35c690. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->