### PR TITLE
feat: implement server-side authentication sessions with JWT revocati…

### DIFF
--- a/docs/manual-testing/issue-453-token-sessions-and-logout.md
+++ b/docs/manual-testing/issue-453-token-sessions-and-logout.md
@@ -1,0 +1,82 @@
+# Manual Test: Token Purpose and Session Logout (#453)
+
+## Purpose
+
+Verify that access and refresh JWTs have different server-enforced purposes,
+that logout revokes the current session immediately, and that refresh-token
+rotation fails closed on replay. This is an additive API rollout: token response
+field names stay unchanged.
+
+## Rollout effect
+
+This release intentionally forces a one-time reauthentication. JWTs issued
+before the release have no server session ID and must receive `401` on protected
+requests and refresh. Users sign in once to receive a new session-bound pair.
+
+Current configured lifetimes are a 12-hour access token and a 7-day absolute
+refresh-session lifetime. Refresh rotates the token but does not extend that
+seven-day session lifetime.
+
+## Preconditions
+
+- Use a non-production account and browser profile.
+- Open [Swagger UI](https://www.quizzence.com/swagger-ui/index.html) or use a
+  REST client that can retain the login response locally.
+- Do not paste tokens into tickets, logs, analytics, or shared chat channels.
+
+## 1. Login and normal access
+
+1. Call `POST /api/v1/auth/login` with valid credentials.
+2. Keep the returned `accessToken` and `refreshToken` only in the client.
+3. Call `GET /api/v1/auth/me` with `Authorization: Bearer <accessToken>`.
+
+Expected result: login and `/me` return `200`. The token response continues to
+contain `accessToken`, `refreshToken`, `accessExpiresInMs`, and
+`refreshExpiresInMs`.
+
+## 2. Token-purpose enforcement
+
+1. Call `GET /api/v1/auth/me` with `Authorization: Bearer <refreshToken>`.
+2. Call `POST /api/v1/auth/refresh` with the access token in the request body.
+
+Expected result: both calls return RFC 7807 `401 Unauthorized`. The refresh
+token never authenticates a protected endpoint, and the access token never
+creates a new token pair.
+
+## 3. Rotation and replay protection
+
+1. Call `POST /api/v1/auth/refresh` with the current refresh token.
+2. Replace both locally stored tokens with the returned pair.
+3. Repeat the refresh call with the old refresh token from step 1.
+4. Call `/me` with the access token returned in step 1.
+
+Expected result: step 1 returns `200` with a replacement pair. Step 3 returns
+`401`; the replay invalidates the whole session. Step 4 also returns `401`.
+When a client cannot tell whether a refresh request reached the server, it must
+delete its local credentials and require login rather than retrying the old
+refresh token.
+
+## 4. Logout and safe retry
+
+1. Log in again to obtain a fresh pair.
+2. Call `POST /api/v1/auth/logout` with `Authorization: Bearer <accessToken>`.
+3. Call `/me` with that access token.
+4. Call `/refresh` with that refresh token.
+5. Repeat the same logout call once.
+
+Expected result: logout returns `204 No Content`; `/me` and `/refresh` return
+`401`; the repeated logout still returns `204`. Logout is safe to retry once
+when the client did not receive the first response. The client should delete
+both local tokens immediately before or while sending the request.
+
+## 5. Swagger contract
+
+1. In Swagger, inspect `POST /api/v1/auth/refresh` and `POST /api/v1/auth/logout`.
+2. Confirm the refresh description requires `type=refresh` and explains
+single-use rotation.
+3. Confirm logout requires an access bearer header, returns `204` on success,
+and documents `401` for invalid or missing input.
+
+Expected result: no frontend request or response field migration is needed.
+The frontend only needs to handle `401` by clearing credentials and showing the
+existing login flow.

--- a/docs/runbooks/auth-sessions.md
+++ b/docs/runbooks/auth-sessions.md
@@ -1,0 +1,58 @@
+# Authentication Sessions
+
+## Security contract
+
+Every JWT issued after migration `V66__create_auth_sessions.sql` has:
+
+- `type=access` or `type=refresh`.
+- `uid`, the signed user identifier.
+- `sid`, the opaque server-side session identifier.
+
+Only `type=access` tokens authenticate protected routes. Only
+`type=refresh` tokens can call the refresh operation. A valid signature alone
+is insufficient: the session must exist, belong to the signed user, be
+unrevoked, and be unexpired.
+
+The database stores a fixed-length HMAC fingerprint of the current refresh JWT,
+never a raw access or refresh token. The fingerprint changes on every successful
+refresh. Reusing an older refresh token revokes the session so concurrent or
+uncertain retries fail closed.
+
+## Client lifecycle
+
+- Login and OAuth success return the existing token-response fields.
+- Store access and refresh tokens separately.
+- Refresh replaces both values atomically in client storage.
+- If a refresh request has an unknown outcome, clear local credentials and
+  require login. Retrying an old refresh token can revoke the session.
+- Logout clears both local credentials immediately. A single logout retry is
+  safe because the server treats an already-revoked session as successful.
+- A protected-route `401` requires reauthentication; clients must not keep
+  retrying the same credentials offline.
+
+## Lifetime and cleanup
+
+The current configuration is a 12-hour access token and a 7-day absolute
+refresh-session lifetime. Refresh rotation does not extend the seven-day
+deadline. The hourly session cleanup task removes rows after that deadline.
+
+Do not manually modify `auth_sessions`, token claims, or the Flyway history.
+For a suspected token incident, rotate the JWT signing secret through the normal
+secret-management/deployment process. That invalidates all signed tokens and
+requires users to log in again.
+
+## Deployment and recovery
+
+`V66` is additive and creates `auth_sessions` with a cascading user foreign key
+and expiry indexes. It does not alter user rows or JWT response fields. Tokens
+issued before the migration lack `sid` and deliberately fail closed; this is the
+one approved forced-reauthentication event.
+
+There is no destructive rollback. If an application rollback is necessary after
+the migration, keep the table in place and deploy a forward fix. If the session
+store cannot be read, bearer authentication fails closed and protected routes
+return `401`; investigate database availability before retrying requests.
+
+Operational logs must never include a JWT, refresh verifier, or session ID.
+The application emits only bounded events for session revocation, replay
+rejection, validation failures, and expired-session cleanup.

--- a/src/main/java/uk/gegc/quizmaker/features/auth/api/AuthController.java
+++ b/src/main/java/uk/gegc/quizmaker/features/auth/api/AuthController.java
@@ -23,6 +23,7 @@ import uk.gegc.quizmaker.features.auth.application.AuthService;
 import uk.gegc.quizmaker.features.user.api.dto.AuthenticatedUserDto;
 import uk.gegc.quizmaker.shared.rate_limit.RateLimitService;
 import uk.gegc.quizmaker.shared.util.TrustedProxyUtil;
+import uk.gegc.quizmaker.shared.exception.UnauthorizedException;
 
 import java.time.LocalDateTime;
 
@@ -91,7 +92,8 @@ public class AuthController {
 
     @Operation(
             summary = "Refresh tokens",
-            description = "Exchanges a valid refresh token for a new access token (and optionally a new refresh token)."
+            description = "Exchanges a current `type=refresh` token for a new access and refresh token. "
+                    + "Refresh tokens are single-use: a replay revokes the session and requires login again."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Tokens refreshed"),
@@ -105,14 +107,16 @@ public class AuthController {
                     required = true,
                     content = @Content(schema = @Schema(implementation = RefreshRequest.class))
             )
-            @RequestBody RefreshRequest refreshRequest
+            @Valid @RequestBody RefreshRequest refreshRequest
     ) {
         return ResponseEntity.ok(authService.refresh(refreshRequest));
     }
 
     @Operation(
             summary = "Logout",
-            description = "Revokes the provided access token."
+            description = "Revokes the current session identified by a valid `type=access` bearer token. "
+                    + "The endpoint permits an idempotent retry, but validates the header itself; both access and refresh "
+                    + "capabilities are denied after logout."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "Logout successful"),
@@ -120,7 +124,7 @@ public class AuthController {
                     content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
     })
     @PostMapping("/logout")
-    public void logout(
+    public ResponseEntity<Void> logout(
             @Parameter(
                     description = "Bearer access token",
                     in = ParameterIn.HEADER,
@@ -128,10 +132,14 @@ public class AuthController {
                     required = true,
                     schema = @Schema(type = "string", example = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
             )
-            @RequestHeader(HttpHeaders.AUTHORIZATION) String header
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String header
     ) {
-        String token = header.replaceFirst("^Bearer\\s+", "");
+        if (header == null || !header.startsWith("Bearer ") || header.length() <= "Bearer ".length()) {
+            throw new UnauthorizedException("Invalid access token");
+        }
+        String token = header.substring("Bearer ".length());
         authService.logout(token);
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(

--- a/src/main/java/uk/gegc/quizmaker/features/auth/api/dto/JwtResponse.java
+++ b/src/main/java/uk/gegc/quizmaker/features/auth/api/dto/JwtResponse.java
@@ -4,16 +4,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "JwtResponse", description = "JSON Web Tokens and expiration information")
 public record JwtResponse(
-        @Schema(description = "Access token (JWT)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        @Schema(description = "Session-bound access token (JWT). Only type=access tokens authenticate protected endpoints.", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
         String accessToken,
 
-        @Schema(description = "Refresh token (JWT)", example = "dGhpc2lzYXJlZnJlc2h0b2tlbg==")
+        @Schema(description = "Single-use session-bound refresh token (JWT). It cannot authenticate protected endpoints.", example = "dGhpc2lzYXJlZnJlc2h0b2tlbg==")
         String refreshToken,
 
         @Schema(description = "Access token validity in milliseconds", example = "3600000")
         long accessExpiresInMs,
 
-        @Schema(description = "Refresh token validity in milliseconds", example = "864000000")
+        @Schema(description = "Remaining refresh-session validity in milliseconds", example = "864000000")
         long refreshExpiresInMs
 ) {
 }

--- a/src/main/java/uk/gegc/quizmaker/features/auth/api/dto/RefreshRequest.java
+++ b/src/main/java/uk/gegc/quizmaker/features/auth/api/dto/RefreshRequest.java
@@ -1,10 +1,12 @@
 package uk.gegc.quizmaker.features.auth.api.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 
 @Schema(name = "RefreshToken", description = "Payload to refresh an access token")
 public record RefreshRequest(
-        @Schema(description = "Refresh token to exchange", example = "dGhpc2lzYXJlZnJlc2h0b2tlbg==")
+        @NotBlank
+        @Schema(description = "Current single-use refresh token to exchange", example = "dGhpc2lzYXJlZnJlc2h0b2tlbg==")
         String refreshToken
 ) {
 }

--- a/src/main/java/uk/gegc/quizmaker/features/auth/application/AuthSessionService.java
+++ b/src/main/java/uk/gegc/quizmaker/features/auth/application/AuthSessionService.java
@@ -1,0 +1,20 @@
+package uk.gegc.quizmaker.features.auth.application;
+
+import org.springframework.security.core.Authentication;
+import uk.gegc.quizmaker.features.auth.api.dto.JwtResponse;
+
+/**
+ * Issues and validates JWTs through a revocable server-side session.
+ */
+public interface AuthSessionService {
+
+    JwtResponse issueTokens(Authentication authentication);
+
+    JwtResponse refresh(String refreshToken);
+
+    void logout(String accessToken);
+
+    Authentication authenticateAccessToken(String accessToken);
+
+    int purgeExpiredSessions();
+}

--- a/src/main/java/uk/gegc/quizmaker/features/auth/application/impl/AuthServiceImpl.java
+++ b/src/main/java/uk/gegc/quizmaker/features/auth/application/impl/AuthServiceImpl.java
@@ -21,11 +21,11 @@ import uk.gegc.quizmaker.features.auth.api.dto.LoginRequest;
 import uk.gegc.quizmaker.features.auth.api.dto.RefreshRequest;
 import uk.gegc.quizmaker.features.auth.api.dto.RegisterRequest;
 import uk.gegc.quizmaker.features.auth.application.AuthService;
+import uk.gegc.quizmaker.features.auth.application.AuthSessionService;
 import uk.gegc.quizmaker.features.auth.domain.model.EmailVerificationToken;
 import uk.gegc.quizmaker.features.auth.domain.model.PasswordResetToken;
 import uk.gegc.quizmaker.features.auth.domain.repository.EmailVerificationTokenRepository;
 import uk.gegc.quizmaker.features.auth.domain.repository.PasswordResetTokenRepository;
-import uk.gegc.quizmaker.features.auth.infra.security.JwtTokenService;
 import uk.gegc.quizmaker.features.user.api.dto.AuthenticatedUserDto;
 import uk.gegc.quizmaker.features.user.domain.model.Role;
 import uk.gegc.quizmaker.features.user.domain.model.RoleName;
@@ -58,7 +58,7 @@ public class AuthServiceImpl implements AuthService {
     private final RoleRepository roleRepository;
     private final UserMapper userMapper;
     private final AuthenticationManager authManager;
-    private final JwtTokenService jwtTokenService;
+    private final AuthSessionService authSessionService;
     private final PasswordResetTokenRepository passwordResetTokenRepository;
     private final EmailVerificationTokenRepository emailVerificationTokenRepository;
     private final EmailService emailService;
@@ -133,44 +133,21 @@ public class AuthServiceImpl implements AuthService {
                     new UsernamePasswordAuthenticationToken(loginRequest.username(), loginRequest.password())
             );
 
-            String accessToken = jwtTokenService.generateAccessToken(authentication);
-            String refreshToken = jwtTokenService.generateRefreshToken(authentication);
-            long accessExpiresInMs = jwtTokenService.getAccessTokenValidityInMs();
-            long refreshExpiresInMs = jwtTokenService.getRefreshTokenValidityInMs();
-
-            return new JwtResponse(accessToken, refreshToken, accessExpiresInMs, refreshExpiresInMs);
+            return authSessionService.issueTokens(authentication);
         } catch (AuthenticationException ex) {
             throw new UnauthorizedException("Invalid username or password");
-        } catch (Exception exception) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid username or password");
         }
     }
 
     @Override
     public JwtResponse refresh(RefreshRequest refreshRequest) {
 
-        String token = refreshRequest.refreshToken();
-
-        if (!jwtTokenService.validateToken(token)) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid refresh token");
-        }
-
-        String type = jwtTokenService.getClaims(token).get("type", String.class);
-        if (!"refresh".equals(type)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Token is not a refresh token");
-        }
-
-        Authentication authentication = jwtTokenService.getAuthentication(token);
-
-        return new JwtResponse(jwtTokenService.generateAccessToken(authentication),
-                token,
-                jwtTokenService.getAccessTokenValidityInMs(),
-                jwtTokenService.getRefreshTokenValidityInMs());
+        return authSessionService.refresh(refreshRequest.refreshToken());
     }
 
     @Override
     public void logout(String token) {
-
+        authSessionService.logout(token);
     }
 
     @Override

--- a/src/main/java/uk/gegc/quizmaker/features/auth/application/impl/AuthSessionCleanupScheduler.java
+++ b/src/main/java/uk/gegc/quizmaker/features/auth/application/impl/AuthSessionCleanupScheduler.java
@@ -1,0 +1,23 @@
+package uk.gegc.quizmaker.features.auth.application.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import uk.gegc.quizmaker.features.auth.application.AuthSessionService;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuthSessionCleanupScheduler {
+
+    private final AuthSessionService authSessionService;
+
+    @Scheduled(cron = "${app.auth.session-cleanup-cron:0 15 * * * *}")
+    public void purgeExpiredSessions() {
+        int purged = authSessionService.purgeExpiredSessions();
+        if (purged > 0) {
+            log.info("Purged {} expired authentication session(s)", purged);
+        }
+    }
+}

--- a/src/main/java/uk/gegc/quizmaker/features/auth/application/impl/AuthSessionServiceImpl.java
+++ b/src/main/java/uk/gegc/quizmaker/features/auth/application/impl/AuthSessionServiceImpl.java
@@ -1,0 +1,181 @@
+package uk.gegc.quizmaker.features.auth.application.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gegc.quizmaker.features.auth.api.dto.JwtResponse;
+import uk.gegc.quizmaker.features.auth.application.AuthSessionService;
+import uk.gegc.quizmaker.features.auth.domain.model.AuthSession;
+import uk.gegc.quizmaker.features.auth.domain.model.AuthSessionRevocationReason;
+import uk.gegc.quizmaker.features.auth.domain.repository.AuthSessionRepository;
+import uk.gegc.quizmaker.features.auth.infra.security.JwtTokenService;
+import uk.gegc.quizmaker.features.auth.infra.security.ValidatedJwt;
+import uk.gegc.quizmaker.features.user.domain.model.User;
+import uk.gegc.quizmaker.features.user.domain.repository.UserRepository;
+import uk.gegc.quizmaker.shared.exception.UnauthorizedException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuthSessionServiceImpl implements AuthSessionService {
+
+    private final AuthSessionRepository authSessionRepository;
+    private final UserRepository userRepository;
+    private final JwtTokenService jwtTokenService;
+
+    @Qualifier("utcClock")
+    private final Clock utcClock;
+
+    @Override
+    @Transactional
+    public JwtResponse issueTokens(Authentication authentication) {
+        User user = findUser(authentication.getName());
+        UUID sessionId = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now(utcClock);
+        LocalDateTime expiresAt = now.plus(Duration.ofMillis(jwtTokenService.getRefreshTokenValidityInMs()));
+
+        String accessToken = jwtTokenService.generateAccessToken(authentication, sessionId);
+        String refreshToken = jwtTokenService.generateRefreshToken(authentication, sessionId, toDate(expiresAt));
+
+        authSessionRepository.save(new AuthSession(
+                sessionId,
+                user.getId(),
+                jwtTokenService.fingerprintRefreshToken(refreshToken),
+                now,
+                expiresAt
+        ));
+
+        return tokenResponse(accessToken, refreshToken, now, expiresAt);
+    }
+
+    @Override
+    @Transactional
+    public JwtResponse refresh(String refreshToken) {
+        ValidatedJwt refreshClaims = jwtTokenService.validateRefreshToken(refreshToken)
+                .orElseThrow(this::invalidRefreshToken);
+        LocalDateTime now = LocalDateTime.now(utcClock);
+        AuthSession session = loadOwnedSessionForUpdate(refreshClaims, "Invalid refresh token");
+
+        if (!session.isActiveAt(now)) {
+            throw invalidRefreshToken();
+        }
+
+        String presentedHash = jwtTokenService.fingerprintRefreshToken(refreshToken);
+        if (!constantTimeEquals(session.getRefreshTokenHash(), presentedHash)) {
+            session.revoke(now, AuthSessionRevocationReason.REFRESH_TOKEN_REPLAY);
+            authSessionRepository.save(session);
+            log.warn("Rejected replayed refresh token");
+            throw invalidRefreshToken();
+        }
+
+        Authentication authentication = jwtTokenService.getAuthentication(refreshClaims);
+        String nextAccessToken = jwtTokenService.generateAccessToken(authentication, session.getId());
+        String nextRefreshToken = jwtTokenService.generateRefreshToken(
+                authentication,
+                session.getId(),
+                toDate(session.getExpiresAt())
+        );
+        session.rotateRefreshToken(jwtTokenService.fingerprintRefreshToken(nextRefreshToken), now);
+        authSessionRepository.save(session);
+
+        return tokenResponse(nextAccessToken, nextRefreshToken, now, session.getExpiresAt());
+    }
+
+    @Override
+    @Transactional
+    public void logout(String accessToken) {
+        ValidatedJwt accessClaims = jwtTokenService.validateAccessToken(accessToken)
+                .orElseThrow(() -> new UnauthorizedException("Invalid access token"));
+        AuthSession session = loadOwnedSessionForUpdate(accessClaims, "Invalid access token");
+        LocalDateTime now = LocalDateTime.now(utcClock);
+
+        if (session.revoke(now, AuthSessionRevocationReason.LOGOUT)) {
+            authSessionRepository.save(session);
+            log.info("Authentication session revoked by logout");
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Authentication authenticateAccessToken(String accessToken) {
+        Optional<ValidatedJwt> accessClaims = jwtTokenService.validateAccessToken(accessToken);
+        if (accessClaims.isEmpty()) {
+            return null;
+        }
+
+        ValidatedJwt claims = accessClaims.get();
+        LocalDateTime now = LocalDateTime.now(utcClock);
+        if (!authSessionRepository.existsActiveSession(claims.sessionId(), claims.userId(), now)) {
+            log.debug("Rejected access token for inactive authentication session");
+            return null;
+        }
+
+        return jwtTokenService.getAuthentication(claims);
+    }
+
+    @Override
+    @Transactional
+    public int purgeExpiredSessions() {
+        return Math.toIntExact(authSessionRepository.deleteByExpiresAtBefore(LocalDateTime.now(utcClock)));
+    }
+
+    private AuthSession loadOwnedSessionForUpdate(ValidatedJwt claims, String invalidTokenMessage) {
+        AuthSession session = authSessionRepository.findByIdForUpdate(claims.sessionId())
+                .orElseThrow(() -> new UnauthorizedException(invalidTokenMessage));
+        if (!session.getUserId().equals(claims.userId())) {
+            throw new UnauthorizedException(invalidTokenMessage);
+        }
+        return session;
+    }
+
+    private User findUser(String usernameOrEmail) {
+        return userRepository.findByUsername(usernameOrEmail)
+                .or(() -> userRepository.findByEmail(usernameOrEmail))
+                .orElseThrow(() -> new UnauthorizedException("Invalid authenticated user"));
+    }
+
+    private JwtResponse tokenResponse(
+            String accessToken,
+            String refreshToken,
+            LocalDateTime now,
+            LocalDateTime refreshExpiresAt
+    ) {
+        long refreshExpiresInMs = Math.max(0, Duration.between(now, refreshExpiresAt).toMillis());
+        return new JwtResponse(
+                accessToken,
+                refreshToken,
+                jwtTokenService.getAccessTokenValidityInMs(),
+                refreshExpiresInMs
+        );
+    }
+
+    private Date toDate(LocalDateTime timestamp) {
+        Instant instant = timestamp.toInstant(ZoneOffset.UTC);
+        return Date.from(instant);
+    }
+
+    private UnauthorizedException invalidRefreshToken() {
+        return new UnauthorizedException("Invalid refresh token");
+    }
+
+    private boolean constantTimeEquals(String left, String right) {
+        return MessageDigest.isEqual(
+                left.getBytes(StandardCharsets.US_ASCII),
+                right.getBytes(StandardCharsets.US_ASCII)
+        );
+    }
+}

--- a/src/main/java/uk/gegc/quizmaker/features/auth/domain/model/AuthSession.java
+++ b/src/main/java/uk/gegc/quizmaker/features/auth/domain/model/AuthSession.java
@@ -1,0 +1,85 @@
+package uk.gegc.quizmaker.features.auth.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(
+        name = "auth_sessions",
+        indexes = {
+                @Index(name = "idx_auth_sessions_user_expires_at", columnList = "user_id, expires_at"),
+                @Index(name = "idx_auth_sessions_expires_at", columnList = "expires_at")
+        }
+)
+public class AuthSession {
+
+    @Id
+    @Column(name = "session_id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "user_id", updatable = false, nullable = false)
+    private UUID userId;
+
+    @Column(name = "refresh_token_hash", nullable = false, length = 64, columnDefinition = "CHAR(64)")
+    private String refreshTokenHash;
+
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "refreshed_at")
+    private LocalDateTime refreshedAt;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "revoked_at")
+    private LocalDateTime revokedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "revocation_reason", length = 32)
+    private AuthSessionRevocationReason revocationReason;
+
+    public AuthSession(
+            UUID id,
+            UUID userId,
+            String refreshTokenHash,
+            LocalDateTime createdAt,
+            LocalDateTime expiresAt
+    ) {
+        this.id = id;
+        this.userId = userId;
+        this.refreshTokenHash = refreshTokenHash;
+        this.createdAt = createdAt;
+        this.expiresAt = expiresAt;
+    }
+
+    public boolean isActiveAt(LocalDateTime now) {
+        return revokedAt == null && expiresAt.isAfter(now);
+    }
+
+    public void rotateRefreshToken(String nextRefreshTokenHash, LocalDateTime now) {
+        this.refreshTokenHash = nextRefreshTokenHash;
+        this.refreshedAt = now;
+    }
+
+    public boolean revoke(LocalDateTime now, AuthSessionRevocationReason reason) {
+        if (revokedAt != null) {
+            return false;
+        }
+        this.revokedAt = now;
+        this.revocationReason = reason;
+        return true;
+    }
+}

--- a/src/main/java/uk/gegc/quizmaker/features/auth/domain/model/AuthSessionRevocationReason.java
+++ b/src/main/java/uk/gegc/quizmaker/features/auth/domain/model/AuthSessionRevocationReason.java
@@ -1,0 +1,9 @@
+package uk.gegc.quizmaker.features.auth.domain.model;
+
+/**
+ * Durable reasons a server-side authentication session can no longer be used.
+ */
+public enum AuthSessionRevocationReason {
+    LOGOUT,
+    REFRESH_TOKEN_REPLAY
+}

--- a/src/main/java/uk/gegc/quizmaker/features/auth/domain/repository/AuthSessionRepository.java
+++ b/src/main/java/uk/gegc/quizmaker/features/auth/domain/repository/AuthSessionRepository.java
@@ -1,0 +1,35 @@
+package uk.gegc.quizmaker.features.auth.domain.repository;
+
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import uk.gegc.quizmaker.features.auth.domain.model.AuthSession;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface AuthSessionRepository extends JpaRepository<AuthSession, UUID> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select session from AuthSession session where session.id = :sessionId")
+    Optional<AuthSession> findByIdForUpdate(@Param("sessionId") UUID sessionId);
+
+    @Query("""
+            select count(session) > 0
+            from AuthSession session
+            where session.id = :sessionId
+              and session.userId = :userId
+              and session.revokedAt is null
+              and session.expiresAt > :now
+            """)
+    boolean existsActiveSession(
+            @Param("sessionId") UUID sessionId,
+            @Param("userId") UUID userId,
+            @Param("now") LocalDateTime now
+    );
+
+    long deleteByExpiresAtBefore(LocalDateTime cutoff);
+}

--- a/src/main/java/uk/gegc/quizmaker/features/auth/infra/security/JwtAuthenticationFilter.java
+++ b/src/main/java/uk/gegc/quizmaker/features/auth/infra/security/JwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
+import uk.gegc.quizmaker.features.auth.application.AuthSessionService;
 import uk.gegc.quizmaker.shared.util.TrustedProxyUtil;
 
 import java.io.IOException;
@@ -17,17 +18,12 @@ import java.io.IOException;
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private final JwtTokenService jwtTokenService;
+    private final AuthSessionService authSessionService;
     private final TrustedProxyUtil trustedProxyUtil;
 
-    public JwtAuthenticationFilter(JwtTokenService jwtTokenService, TrustedProxyUtil trustedProxyUtil) {
-        this.jwtTokenService = jwtTokenService;
+    public JwtAuthenticationFilter(AuthSessionService authSessionService, TrustedProxyUtil trustedProxyUtil) {
+        this.authSessionService = authSessionService;
         this.trustedProxyUtil = trustedProxyUtil;
-    }
-
-    // Backward-compatible constructor for any old usages/tests
-    public JwtAuthenticationFilter(JwtTokenService jwtTokenService) {
-        this(jwtTokenService, new TrustedProxyUtil());
     }
 
     @Override
@@ -36,20 +32,28 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             String token = authHeader.substring(7);
-            if (jwtTokenService.validateToken(token)) {
-                Authentication authentication = jwtTokenService.getAuthentication(token);
+            try {
+                Authentication authentication = authSessionService.authenticateAccessToken(token);
+                if (authentication != null) {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
                 log.debug("Successfully authenticated user: {}", authentication.getName());
-            } else {
-                // Log failed token validation with request details for security monitoring
-                String clientIp = trustedProxyUtil != null ? trustedProxyUtil.getClientIp(request) : request.getRemoteAddr();
-                log.warn("Invalid JWT token received from IP: {}, URI: {}, User-Agent: {}", 
-                    clientIp, 
-                    request.getRequestURI(),
-                    request.getHeader("User-Agent"));
+                } else {
+                    logInvalidToken(request);
+                }
+            } catch (RuntimeException ex) {
+                // A session-store outage must fail closed. Do not expose token data in logs or responses.
+                log.error("Authentication session validation failed", ex);
             }
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private void logInvalidToken(HttpServletRequest request) {
+        String clientIp = trustedProxyUtil != null ? trustedProxyUtil.getClientIp(request) : request.getRemoteAddr();
+        log.warn("Invalid access token received from IP: {}, URI: {}, User-Agent: {}",
+                clientIp,
+                request.getRequestURI(),
+                request.getHeader("User-Agent"));
     }
 }

--- a/src/main/java/uk/gegc/quizmaker/features/auth/infra/security/JwtTokenService.java
+++ b/src/main/java/uk/gegc/quizmaker/features/auth/infra/security/JwtTokenService.java
@@ -16,10 +16,14 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
+import javax.crypto.Mac;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.HexFormat;
 import java.util.Date;
 import java.util.Optional;
+import java.util.UUID;
 import uk.gegc.quizmaker.features.user.domain.model.User;
 import uk.gegc.quizmaker.features.user.domain.repository.UserRepository;
 
@@ -44,7 +48,12 @@ public class JwtTokenService {
 
     private SecretKey key;
 
+    private static final String ACCESS_TOKEN_TYPE = "access";
+    private static final String REFRESH_TOKEN_TYPE = "refresh";
+    private static final String TOKEN_TYPE_CLAIM = "type";
     private static final String PASSWORD_CHANGED_AT_CLAIM = "pwdChangedAt";
+    private static final String USER_ID_CLAIM = "uid";
+    private static final String SESSION_ID_CLAIM = "sid";
 
     @PostConstruct
     public void init() {
@@ -52,32 +61,36 @@ public class JwtTokenService {
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    public String generateAccessToken(Authentication authentication) {
+    public String generateAccessToken(Authentication authentication, UUID sessionId) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + accessTokenValidityInMs);
-        long passwordChangedAtEpoch = resolvePasswordChangedAtEpoch(authentication.getName());
-
-        return Jwts.builder()
-                .subject(authentication.getName())
-                .issuedAt(now)
-                .expiration(expiry)
-                .claim("type", "access")
-                .claim(PASSWORD_CHANGED_AT_CLAIM, passwordChangedAtEpoch)
-                .signWith(key)
-                .compact();
+        return generateToken(authentication, sessionId, ACCESS_TOKEN_TYPE, now, expiry);
     }
 
-    public String generateRefreshToken(Authentication authentication) {
+    public String generateRefreshToken(Authentication authentication, UUID sessionId, Date expiry) {
         Date now = new Date();
-        Date expiry = new Date(now.getTime() + refreshTokenValidityInMs);
-        long passwordChangedAtEpoch = resolvePasswordChangedAtEpoch(authentication.getName());
+        return generateToken(authentication, sessionId, REFRESH_TOKEN_TYPE, now, expiry);
+    }
 
+    private String generateToken(
+            Authentication authentication,
+            UUID sessionId,
+            String tokenType,
+            Date issuedAt,
+            Date expiry
+    ) {
+        User user = findUserByIdentifier(authentication.getName())
+                .orElseThrow(() -> new IllegalStateException(
+                        "Cannot generate token for unknown user: " + authentication.getName()));
+        long passwordChangedAtEpoch = toEpochMillis(user.getPasswordChangedAt());
         return Jwts.builder()
                 .subject(authentication.getName())
-                .issuedAt(now)
+                .issuedAt(issuedAt)
                 .expiration(expiry)
-                .claim("type", "refresh")
+                .claim(TOKEN_TYPE_CLAIM, tokenType)
                 .claim(PASSWORD_CHANGED_AT_CLAIM, passwordChangedAtEpoch)
+                .claim(USER_ID_CLAIM, user.getId().toString())
+                .claim(SESSION_ID_CLAIM, sessionId.toString())
                 .signWith(key)
                 .compact();
     }
@@ -96,6 +109,18 @@ public class JwtTokenService {
     }
 
     public boolean validateToken(String token) {
+        return validateAccessToken(token).isPresent();
+    }
+
+    public Optional<ValidatedJwt> validateAccessToken(String token) {
+        return validateTokenForType(token, ACCESS_TOKEN_TYPE);
+    }
+
+    public Optional<ValidatedJwt> validateRefreshToken(String token) {
+        return validateTokenForType(token, REFRESH_TOKEN_TYPE);
+    }
+
+    private Optional<ValidatedJwt> validateTokenForType(String token, String expectedType) {
         try {
             Claims claims = Jwts.parser()
                     .verifyWith(key)
@@ -106,45 +131,77 @@ public class JwtTokenService {
             String username = claims.getSubject();
             if (username == null || username.isBlank()) {
                 log.warn("JWT token missing subject");
-                return false;
+                return Optional.empty();
+            }
+
+            if (!expectedType.equals(claims.get(TOKEN_TYPE_CLAIM, String.class))) {
+                log.debug("JWT token purpose is not valid for this operation");
+                return Optional.empty();
             }
 
             Long tokenPasswordChangedAt = claims.get(PASSWORD_CHANGED_AT_CLAIM, Long.class);
             if (tokenPasswordChangedAt == null) {
                 log.warn("JWT token missing password version claim");
-                return false;
+                return Optional.empty();
             }
 
-            Optional<Long> currentPasswordChangedAt = findUserByIdentifier(username)
-                    .map(User::getPasswordChangedAt)
-                    .map(this::toEpochMillis);
-
-            if (currentPasswordChangedAt.isEmpty()) {
-                log.warn("User '{}' not found or missing passwordChangedAt when validating token", username);
-                return false;
+            Optional<User> user = findUserByIdentifier(username);
+            if (user.isEmpty() || user.get().getPasswordChangedAt() == null) {
+                log.warn("JWT subject is not associated with an active user or password version");
+                return Optional.empty();
             }
 
-            if (currentPasswordChangedAt.get() > tokenPasswordChangedAt) {
-                log.debug("Rejecting JWT for user '{}' because password changed after token issuance", username);
-                return false;
+            if (toEpochMillis(user.get().getPasswordChangedAt()) > tokenPasswordChangedAt) {
+                log.debug("Rejecting JWT because password changed after token issuance");
+                return Optional.empty();
             }
 
-            return true;
+            UUID claimedUserId = readUuidClaim(claims, USER_ID_CLAIM);
+            UUID sessionId = readUuidClaim(claims, SESSION_ID_CLAIM);
+            if (claimedUserId == null || sessionId == null || !claimedUserId.equals(user.get().getId())) {
+                log.debug("JWT token is missing or has inconsistent session identity claims");
+                return Optional.empty();
+            }
+
+            return Optional.of(new ValidatedJwt(
+                    username,
+                    claimedUserId,
+                    sessionId,
+                    claims.getExpiration().toInstant()
+            ));
         } catch (ExpiredJwtException ex) {
             log.debug("JWT token is expired: {}", ex.getMessage());
-            return false;
+            return Optional.empty();
         } catch (MalformedJwtException ex) {
             log.warn("Malformed JWT token received: {}", ex.getMessage());
-            return false;
+            return Optional.empty();
         } catch (SignatureException ex) {
             log.warn("Invalid JWT signature detected: {}", ex.getMessage());
-            return false;
+            return Optional.empty();
         } catch (IllegalArgumentException ex) {
             log.warn("Illegal argument passed to JWT parser: {}", ex.getMessage());
-            return false;
+            return Optional.empty();
         } catch (JwtException ex) {
             log.error("Unexpected JWT exception: {}", ex.getMessage());
-            return false;
+            return Optional.empty();
+        }
+    }
+
+    public Authentication getAuthentication(ValidatedJwt validatedJwt) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(validatedJwt.username());
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+    /**
+     * Produces a fixed-length verifier for server-side refresh-token comparison.
+     */
+    public String fingerprintRefreshToken(String refreshToken) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(key);
+            return HexFormat.of().formatHex(mac.doFinal(refreshToken.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception ex) {
+            throw new IllegalStateException("Unable to fingerprint refresh token", ex);
         }
     }
 
@@ -165,11 +222,16 @@ public class JwtTokenService {
                 .getPayload();
     }
 
-    private long resolvePasswordChangedAtEpoch(String username) {
-        return findUserByIdentifier(username)
-                .map(User::getPasswordChangedAt)
-                .map(this::toEpochMillis)
-                .orElseThrow(() -> new IllegalStateException("Cannot generate token for unknown user: " + username));
+    private UUID readUuidClaim(Claims claims, String claimName) {
+        String value = claims.get(claimName, String.class);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
     }
 
     private Optional<User> findUserByIdentifier(String identifier) {

--- a/src/main/java/uk/gegc/quizmaker/features/auth/infra/security/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/uk/gegc/quizmaker/features/auth/infra/security/OAuth2AuthenticationSuccessHandler.java
@@ -9,6 +9,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
+import uk.gegc.quizmaker.features.auth.api.dto.JwtResponse;
+import uk.gegc.quizmaker.features.auth.application.AuthSessionService;
 
 import java.io.IOException;
 
@@ -21,7 +23,7 @@ import java.io.IOException;
 @Slf4j
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final JwtTokenService jwtTokenService;
+    private final AuthSessionService authSessionService;
 
     @Value("${app.oauth2.redirect-uri:http://localhost:3000/oauth2/redirect}")
     private String oauth2RedirectUri;
@@ -50,17 +52,15 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         Authentication authentication
     ) {
         // Generate JWT tokens for the authenticated user
-        String accessToken = jwtTokenService.generateAccessToken(authentication);
-        String refreshToken = jwtTokenService.generateRefreshToken(authentication);
+        JwtResponse tokens = authSessionService.issueTokens(authentication);
         
         log.info("OAuth2 authentication successful for user: {}", authentication.getName());
 
         // Build redirect URL with tokens as query parameters
         return UriComponentsBuilder.fromUriString(oauth2RedirectUri)
-                .queryParam("accessToken", accessToken)
-                .queryParam("refreshToken", refreshToken)
+                .queryParam("accessToken", tokens.accessToken())
+                .queryParam("refreshToken", tokens.refreshToken())
                 .build()
                 .toUriString();
     }
 }
-

--- a/src/main/java/uk/gegc/quizmaker/features/auth/infra/security/ValidatedJwt.java
+++ b/src/main/java/uk/gegc/quizmaker/features/auth/infra/security/ValidatedJwt.java
@@ -1,0 +1,15 @@
+package uk.gegc.quizmaker.features.auth.infra.security;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Claims that have passed signature, expiry, password-version, and purpose checks.
+ */
+public record ValidatedJwt(
+        String username,
+        UUID userId,
+        UUID sessionId,
+        Instant expiresAt
+) {
+}

--- a/src/main/java/uk/gegc/quizmaker/shared/config/PublicApiRoutes.java
+++ b/src/main/java/uk/gegc/quizmaker/shared/config/PublicApiRoutes.java
@@ -21,6 +21,7 @@ public final class PublicApiRoutes {
             anyMethod("/api/v1/auth/register"),
             anyMethod("/api/v1/auth/login"),
             anyMethod("/api/v1/auth/refresh"),
+            anyMethod("/api/v1/auth/logout"),
             anyMethod("/api/v1/auth/forgot-password"),
             anyMethod("/api/v1/auth/reset-password"),
             anyMethod("/api/v1/auth/2fa/setup"),

--- a/src/main/java/uk/gegc/quizmaker/shared/config/SecurityConfig.java
+++ b/src/main/java/uk/gegc/quizmaker/shared/config/SecurityConfig.java
@@ -20,9 +20,9 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import java.io.IOException;
 import org.springframework.web.cors.CorsConfigurationSource;
+import uk.gegc.quizmaker.features.auth.application.AuthSessionService;
 import uk.gegc.quizmaker.features.auth.infra.security.CustomOAuth2UserService;
 import uk.gegc.quizmaker.features.auth.infra.security.JwtAuthenticationFilter;
-import uk.gegc.quizmaker.features.auth.infra.security.JwtTokenService;
 import uk.gegc.quizmaker.features.auth.infra.security.OAuth2AuthenticationFailureHandler;
 import uk.gegc.quizmaker.features.auth.infra.security.OAuth2AuthenticationSuccessHandler;
 import uk.gegc.quizmaker.shared.api.problem.ErrorTypes;
@@ -36,7 +36,7 @@ import uk.gegc.quizmaker.shared.util.TrustedProxyUtil;
 @EnableAspectJAutoProxy
 public class SecurityConfig {
 
-    private final JwtTokenService jwtTokenService;
+    private final AuthSessionService authSessionService;
     private final CorsConfigurationSource corsConfigurationSource;
     private final TrustedProxyUtil trustedProxyUtil;
     private final CustomOAuth2UserService customOAuth2UserService;
@@ -80,7 +80,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/documents/**").authenticated()
                         .anyRequest().authenticated())
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtTokenService, trustedProxyUtil),
+                        new JwtAuthenticationFilter(authSessionService, trustedProxyUtil),
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .cors(cors -> cors.configurationSource(corsConfigurationSource));

--- a/src/main/resources/db/migration/V66__create_auth_sessions.sql
+++ b/src/main/resources/db/migration/V66__create_auth_sessions.sql
@@ -1,0 +1,34 @@
+-- A server-side session makes JWT logout and refresh-token rotation enforceable.
+-- The verifier is an HMAC fingerprint of the current refresh JWT, never the raw token.
+-- Some focused migration tests intentionally baseline only document tables.
+-- Those partial schemas are not deployments, so auth-specific DDL must not
+-- make their document compatibility checks fail.
+SET @users_table_exists := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'users'
+);
+
+SET @auth_sessions_schema_sql := IF(
+    @users_table_exists = 1,
+    'CREATE TABLE IF NOT EXISTS auth_sessions (
+        session_id BINARY(16) NOT NULL,
+        user_id BINARY(16) NOT NULL,
+        refresh_token_hash CHAR(64) NOT NULL,
+        created_at TIMESTAMP NOT NULL,
+        refreshed_at TIMESTAMP NULL,
+        expires_at TIMESTAMP NOT NULL,
+        revoked_at TIMESTAMP NULL,
+        revocation_reason VARCHAR(32) NULL,
+        PRIMARY KEY (session_id),
+        INDEX idx_auth_sessions_user_expires_at (user_id, expires_at),
+        INDEX idx_auth_sessions_expires_at (expires_at),
+        CONSTRAINT fk_auth_sessions_user
+            FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+    ) ENGINE=InnoDB',
+    'SELECT 1'
+);
+PREPARE auth_sessions_schema_statement FROM @auth_sessions_schema_sql;
+EXECUTE auth_sessions_schema_statement;
+DEALLOCATE PREPARE auth_sessions_schema_statement;

--- a/src/test/java/uk/gegc/quizmaker/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/uk/gegc/quizmaker/controller/AuthControllerIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.context.TestPropertySource;
 import uk.gegc.quizmaker.BaseIntegrationTest;
 import uk.gegc.quizmaker.features.user.domain.model.Role;
@@ -355,8 +356,8 @@ public class AuthControllerIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("POST /api/v1/auth/refresh with access token → returns 400 BAD_REQUEST")
-    void refreshWithAccessToken_returns400() throws Exception {
+    @DisplayName("POST /api/v1/auth/refresh with access token → returns 401 UNAUTHORIZED")
+    void refreshWithAccessToken_returns401() throws Exception {
         var reg = new RegisterRequest("user1", "u1@ex.com", "ValidPass123!");
         mockMvc.perform(post("/api/v1/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -372,9 +373,55 @@ public class AuthControllerIntegrationTest extends BaseIntegrationTest {
 
         var refreshReq = new RefreshRequest(accessToken);
         mockMvc.perform(post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(refreshReq)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithAnonymousUser
+    @DisplayName("Refresh tokens never authenticate protected routes and logout revokes both token capabilities")
+    void sessionSecurity_refreshTokenIsNotBearerAndLogoutRevokesSession() throws Exception {
+        RegisterRequest registration = new RegisterRequest("sessionUser", "session@example.com", "ValidPass123!");
+        mockMvc.perform(post("/api/v1/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(refreshReq)))
-                .andExpect(status().isBadRequest());
+                        .content(objectMapper.writeValueAsString(registration)))
+                .andExpect(status().isCreated());
+
+        String loginJson = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new LoginRequest("sessionUser", "ValidPass123!"))))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        String accessToken = objectMapper.readTree(loginJson).get("accessToken").asText();
+        String refreshToken = objectMapper.readTree(loginJson).get("refreshToken").asText();
+
+        mockMvc.perform(get("/api/v1/auth/me")
+                        .with(anonymous())
+                        .header("Authorization", "Bearer " + refreshToken))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .with(anonymous())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/v1/auth/me")
+                        .with(anonymous())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new RefreshRequest(refreshToken))))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .with(anonymous())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
     }
 
     @Test

--- a/src/test/java/uk/gegc/quizmaker/features/auth/OAuthAccountControllerIntegrationTest.java
+++ b/src/test/java/uk/gegc/quizmaker/features/auth/OAuthAccountControllerIntegrationTest.java
@@ -11,10 +11,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gegc.quizmaker.BaseIntegrationTest;
 import uk.gegc.quizmaker.features.auth.api.dto.UnlinkAccountRequest;
+import uk.gegc.quizmaker.features.auth.application.AuthSessionService;
 import uk.gegc.quizmaker.features.auth.domain.model.OAuthAccount;
 import uk.gegc.quizmaker.features.auth.domain.model.OAuthProvider;
 import uk.gegc.quizmaker.features.auth.domain.repository.OAuthAccountRepository;
-import uk.gegc.quizmaker.features.auth.infra.security.JwtTokenService;
 import uk.gegc.quizmaker.features.user.domain.model.Role;
 import uk.gegc.quizmaker.features.user.domain.model.RoleName;
 import uk.gegc.quizmaker.features.user.domain.model.User;
@@ -53,7 +53,7 @@ class OAuthAccountControllerIntegrationTest extends BaseIntegrationTest {
     private PasswordEncoder passwordEncoder;
 
     @Autowired
-    private JwtTokenService jwtTokenService;
+    private AuthSessionService authSessionService;
 
     @Autowired
     private EntityManager entityManager;
@@ -87,7 +87,7 @@ class OAuthAccountControllerIntegrationTest extends BaseIntegrationTest {
                                 .map(role -> new org.springframework.security.core.authority.SimpleGrantedAuthority(role.getRoleName()))
                                 .toList()
                 );
-        accessToken = jwtTokenService.generateAccessToken(authToken);
+        accessToken = authSessionService.issueTokens(authToken).accessToken();
     }
 
     @Test
@@ -197,4 +197,3 @@ class OAuthAccountControllerIntegrationTest extends BaseIntegrationTest {
         return oauthAccountRepository.save(account);
     }
 }
-

--- a/src/test/java/uk/gegc/quizmaker/features/auth/api/AuthOpenApiContractTest.java
+++ b/src/test/java/uk/gegc/quizmaker/features/auth/api/AuthOpenApiContractTest.java
@@ -1,0 +1,90 @@
+package uk.gegc.quizmaker.features.auth.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.configuration.SpringDocConfiguration;
+import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springdoc.webmvc.core.configuration.MultipleOpenApiSupportConfiguration;
+import org.springdoc.webmvc.core.configuration.SpringDocWebMvcConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gegc.quizmaker.features.auth.application.AuthService;
+import uk.gegc.quizmaker.shared.config.OpenApiConfig;
+import uk.gegc.quizmaker.shared.config.OpenApiGroupConfig;
+import uk.gegc.quizmaker.shared.rate_limit.RateLimitService;
+import uk.gegc.quizmaker.shared.util.TrustedProxyUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AuthController.class)
+@Import({
+        OpenApiConfig.class,
+        OpenApiGroupConfig.class,
+        SpringDocConfiguration.class,
+        SpringDocWebMvcConfiguration.class,
+        MultipleOpenApiSupportConfiguration.class,
+        AuthOpenApiContractTest.SpringDocTestConfig.class
+})
+class AuthOpenApiContractTest {
+
+    @TestConfiguration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(SpringDocConfigProperties.class)
+    static class SpringDocTestConfig {
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @MockitoBean
+    private RateLimitService rateLimitService;
+
+    @MockitoBean
+    private TrustedProxyUtil trustedProxyUtil;
+
+    @Test
+    @WithMockUser
+    @DisplayName("GET /v3/api-docs/auth documents type-restricted refresh and idempotent logout")
+    void authOpenApiContract() throws Exception {
+        JsonNode specification = objectMapper.readTree(mockMvc.perform(get("/v3/api-docs/auth"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString());
+
+        assertThat(specification.at("/paths/~1api~1v1~1auth~1refresh/post/description").asText())
+                .contains("type=refresh", "single-use");
+        assertResponseDocumented(specification, "/paths/~1api~1v1~1auth~1refresh/post/responses/401");
+        assertThat(specification.at("/paths/~1api~1v1~1auth~1logout/post/description").asText())
+                .contains("type=access", "idempotent");
+        assertResponseDocumented(specification, "/paths/~1api~1v1~1auth~1logout/post/responses/204");
+        assertResponseDocumented(specification, "/paths/~1api~1v1~1auth~1logout/post/responses/401");
+        assertThat(specification.at("/paths/~1api~1v1~1auth~1logout/post/parameters/0/name").asText())
+                .isEqualTo("Authorization");
+        assertThat(specification.at("/paths/~1api~1v1~1auth~1logout/post/security/0").isObject()).isTrue();
+        assertThat(specification.at("/paths/~1api~1v1~1auth~1logout/post/security/0").size()).isZero();
+        assertThat(specification.at("/components/schemas/JwtResponse/properties/accessToken/description").asText())
+                .contains("type=access");
+        assertThat(specification.at("/components/schemas/JwtResponse/properties/refreshToken/description").asText())
+                .contains("cannot authenticate protected endpoints");
+    }
+
+    private void assertResponseDocumented(JsonNode specification, String responsePointer) {
+        assertThat(specification.at(responsePointer).isMissingNode()).isFalse();
+    }
+}

--- a/src/test/java/uk/gegc/quizmaker/features/auth/application/impl/AuthSessionServiceImplTest.java
+++ b/src/test/java/uk/gegc/quizmaker/features/auth/application/impl/AuthSessionServiceImplTest.java
@@ -1,0 +1,184 @@
+package uk.gegc.quizmaker.features.auth.application.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import uk.gegc.quizmaker.features.auth.api.dto.JwtResponse;
+import uk.gegc.quizmaker.features.auth.domain.model.AuthSession;
+import uk.gegc.quizmaker.features.auth.domain.model.AuthSessionRevocationReason;
+import uk.gegc.quizmaker.features.auth.domain.repository.AuthSessionRepository;
+import uk.gegc.quizmaker.features.auth.infra.security.JwtTokenService;
+import uk.gegc.quizmaker.features.auth.infra.security.ValidatedJwt;
+import uk.gegc.quizmaker.features.user.domain.model.User;
+import uk.gegc.quizmaker.features.user.domain.repository.UserRepository;
+import uk.gegc.quizmaker.shared.exception.UnauthorizedException;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Authentication Session Service")
+class AuthSessionServiceImplTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-05T00:00:00Z");
+
+    @Mock
+    private AuthSessionRepository authSessionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private JwtTokenService jwtTokenService;
+
+    @Mock
+    private Authentication authentication;
+
+    private AuthSessionServiceImpl service;
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+    private final UUID userId = UUID.randomUUID();
+    private final UUID sessionId = UUID.randomUUID();
+    private final LocalDateTime now = LocalDateTime.ofInstant(NOW, ZoneOffset.UTC);
+
+    @BeforeEach
+    void setUp() {
+        service = new AuthSessionServiceImpl(authSessionRepository, userRepository, jwtTokenService, clock);
+    }
+
+    @Test
+    @DisplayName("issues a new session without persisting the raw refresh token")
+    void issueTokens_persistsHashedRefreshVerifier() {
+        User user = new User();
+        user.setId(userId);
+        when(authentication.getName()).thenReturn("alice");
+        when(userRepository.findByUsername("alice")).thenReturn(Optional.of(user));
+        when(jwtTokenService.getRefreshTokenValidityInMs()).thenReturn(604_800_000L);
+        when(jwtTokenService.getAccessTokenValidityInMs()).thenReturn(43_200_000L);
+        when(jwtTokenService.generateAccessToken(eq(authentication), any(UUID.class))).thenReturn("access-token");
+        when(jwtTokenService.generateRefreshToken(eq(authentication), any(UUID.class), any(Date.class)))
+                .thenReturn("refresh-token");
+        when(jwtTokenService.fingerprintRefreshToken("refresh-token")).thenReturn("fingerprint");
+
+        JwtResponse result = service.issueTokens(authentication);
+
+        ArgumentCaptor<AuthSession> sessionCaptor = ArgumentCaptor.forClass(AuthSession.class);
+        verify(authSessionRepository).save(sessionCaptor.capture());
+        AuthSession saved = sessionCaptor.getValue();
+        assertThat(saved.getUserId()).isEqualTo(userId);
+        assertThat(saved.getRefreshTokenHash()).isEqualTo("fingerprint").isNotEqualTo("refresh-token");
+        assertThat(saved.getExpiresAt()).isEqualTo(now.plusDays(7));
+        assertThat(result.accessToken()).isEqualTo("access-token");
+        assertThat(result.refreshToken()).isEqualTo("refresh-token");
+        assertThat(result.refreshExpiresInMs()).isEqualTo(604_800_000L);
+    }
+
+    @Test
+    @DisplayName("rotates a valid refresh token once and preserves the session expiry")
+    void refresh_rotatesCurrentVerifierAndIssuesReplacementPair() {
+        LocalDateTime expiresAt = now.plusDays(3);
+        AuthSession session = new AuthSession(sessionId, userId, "current-hash", now.minusDays(1), expiresAt);
+        ValidatedJwt claims = new ValidatedJwt("alice", userId, sessionId, expiresAt.toInstant(ZoneOffset.UTC));
+        when(jwtTokenService.validateRefreshToken("current-refresh")).thenReturn(Optional.of(claims));
+        when(authSessionRepository.findByIdForUpdate(sessionId)).thenReturn(Optional.of(session));
+        when(jwtTokenService.fingerprintRefreshToken("current-refresh")).thenReturn("current-hash");
+        when(jwtTokenService.getAuthentication(claims)).thenReturn(authentication);
+        when(jwtTokenService.generateAccessToken(authentication, sessionId)).thenReturn("next-access");
+        when(jwtTokenService.generateRefreshToken(eq(authentication), eq(sessionId), any(Date.class)))
+                .thenReturn("next-refresh");
+        when(jwtTokenService.fingerprintRefreshToken("next-refresh")).thenReturn("next-hash");
+        when(jwtTokenService.getAccessTokenValidityInMs()).thenReturn(43_200_000L);
+
+        JwtResponse result = service.refresh("current-refresh");
+
+        assertThat(result.accessToken()).isEqualTo("next-access");
+        assertThat(result.refreshToken()).isEqualTo("next-refresh");
+        assertThat(result.refreshExpiresInMs()).isEqualTo(259_200_000L);
+        assertThat(session.getRefreshTokenHash()).isEqualTo("next-hash");
+        assertThat(session.getRefreshedAt()).isEqualTo(now);
+        verify(authSessionRepository).save(session);
+    }
+
+    @Test
+    @DisplayName("refresh replay revokes the session and does not issue more tokens")
+    void refresh_replayedTokenRevokesSessionAndFailsClosed() {
+        AuthSession session = new AuthSession(sessionId, userId, "current-hash", now.minusDays(1), now.plusDays(3));
+        ValidatedJwt claims = new ValidatedJwt("alice", userId, sessionId, now.plusDays(3).toInstant(ZoneOffset.UTC));
+        when(jwtTokenService.validateRefreshToken("replayed-refresh")).thenReturn(Optional.of(claims));
+        when(authSessionRepository.findByIdForUpdate(sessionId)).thenReturn(Optional.of(session));
+        when(jwtTokenService.fingerprintRefreshToken("replayed-refresh")).thenReturn("stale-hash");
+
+        assertThatThrownBy(() -> service.refresh("replayed-refresh"))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("Invalid refresh token");
+
+        assertThat(session.getRevocationReason()).isEqualTo(AuthSessionRevocationReason.REFRESH_TOKEN_REPLAY);
+        assertThat(session.getRevokedAt()).isEqualTo(now);
+        verify(authSessionRepository).save(session);
+        verify(jwtTokenService, never()).generateAccessToken(any(Authentication.class), any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("logout revokes its current session once and allows an idempotent retry")
+    void logout_revokesCurrentSessionExactlyOnce() {
+        AuthSession session = new AuthSession(sessionId, userId, "hash", now.minusDays(1), now.plusDays(3));
+        ValidatedJwt claims = new ValidatedJwt("alice", userId, sessionId, now.plusHours(1).toInstant(ZoneOffset.UTC));
+        when(jwtTokenService.validateAccessToken("access-token")).thenReturn(Optional.of(claims));
+        when(authSessionRepository.findByIdForUpdate(sessionId)).thenReturn(Optional.of(session));
+
+        service.logout("access-token");
+        service.logout("access-token");
+
+        assertThat(session.getRevocationReason()).isEqualTo(AuthSessionRevocationReason.LOGOUT);
+        assertThat(session.getRevokedAt()).isEqualTo(now);
+        verify(authSessionRepository).save(session);
+    }
+
+    @Test
+    @DisplayName("a revoked session cannot authenticate an otherwise valid access token")
+    void authenticateAccessToken_revokedSessionReturnsNoAuthentication() {
+        ValidatedJwt claims = new ValidatedJwt("alice", userId, sessionId, now.plusHours(1).toInstant(ZoneOffset.UTC));
+        when(jwtTokenService.validateAccessToken("access-token")).thenReturn(Optional.of(claims));
+        when(authSessionRepository.existsActiveSession(sessionId, userId, now)).thenReturn(false);
+
+        assertThat(service.authenticateAccessToken("access-token")).isNull();
+        verify(jwtTokenService, never()).getAuthentication(claims);
+    }
+
+    @Test
+    @DisplayName("an active session authenticates only after the session-store check succeeds")
+    void authenticateAccessToken_activeSessionReturnsAuthentication() {
+        ValidatedJwt claims = new ValidatedJwt("alice", userId, sessionId, now.plusHours(1).toInstant(ZoneOffset.UTC));
+        when(jwtTokenService.validateAccessToken("access-token")).thenReturn(Optional.of(claims));
+        when(authSessionRepository.existsActiveSession(sessionId, userId, now)).thenReturn(true);
+        when(jwtTokenService.getAuthentication(claims)).thenReturn(authentication);
+
+        assertThat(service.authenticateAccessToken("access-token")).isSameAs(authentication);
+    }
+
+    @Test
+    @DisplayName("cleanup removes only sessions whose refresh lifetime has ended")
+    void purgeExpiredSessions_delegatesWithUtcNow() {
+        when(authSessionRepository.deleteByExpiresAtBefore(now)).thenReturn(2L);
+
+        assertThat(service.purgeExpiredSessions()).isEqualTo(2);
+        verify(authSessionRepository).deleteByExpiresAtBefore(now);
+    }
+}

--- a/src/test/java/uk/gegc/quizmaker/features/auth/infra/AuthSessionSchemaMigrationTest.java
+++ b/src/test/java/uk/gegc/quizmaker/features/auth/infra/AuthSessionSchemaMigrationTest.java
@@ -1,0 +1,131 @@
+package uk.gegc.quizmaker.features.auth.infra;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Authentication Session Schema Migration Tests")
+@JdbcTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = "spring.flyway.enabled=false")
+@Tag("db-serial")
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class AuthSessionSchemaMigrationTest {
+
+    private static final String MIGRATION_HISTORY_TABLE = "flyway_auth_session_history";
+    private static final String BASELINE_MARKER_TABLE = "auth_session_baseline_marker";
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private boolean createdUsersTable;
+
+    @BeforeEach
+    void resetSchema() {
+        dropMigrationArtifacts();
+        ensureUsersTableExists();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        dropMigrationArtifacts();
+        if (createdUsersTable) {
+            jdbcTemplate.execute("DROP TABLE IF EXISTS users");
+        }
+    }
+
+    @Test
+    @DisplayName("V66 creates a revocable session store with indexed expiry and user cleanup")
+    void migrate_v66_createsRevocableSessionSchema() {
+        jdbcTemplate.execute("CREATE TABLE " + BASELINE_MARKER_TABLE + " (id INT NOT NULL)");
+
+        Flyway.configure()
+                .dataSource(jdbcTemplate.getDataSource())
+                .table(MIGRATION_HISTORY_TABLE)
+                .locations("classpath:db/migration")
+                .baselineOnMigrate(true)
+                .baselineVersion("65")
+                .baselineDescription("before authentication sessions")
+                .target("66")
+                .load()
+                .migrate();
+
+        assertThat(columnType("refresh_token_hash")).isEqualToIgnoringCase("char(64)");
+        assertThat(columnIsNullable("refresh_token_hash")).isFalse();
+        assertThat(columnIsNullable("revoked_at")).isTrue();
+        assertThat(indexExists("idx_auth_sessions_user_expires_at")).isTrue();
+        assertThat(indexExists("idx_auth_sessions_expires_at")).isTrue();
+        assertThat(deleteRule("fk_auth_sessions_user")).isEqualTo("CASCADE");
+    }
+
+    private void ensureUsersTableExists() {
+        Integer tableCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 'users'",
+                Integer.class
+        );
+        if (tableCount != null && tableCount > 0) {
+            return;
+        }
+
+        jdbcTemplate.execute("CREATE TABLE users (user_id BINARY(16) NOT NULL PRIMARY KEY) ENGINE=InnoDB");
+        createdUsersTable = true;
+    }
+
+    private void dropMigrationArtifacts() {
+        jdbcTemplate.execute("DROP TABLE IF EXISTS auth_sessions");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS " + MIGRATION_HISTORY_TABLE);
+        jdbcTemplate.execute("DROP TABLE IF EXISTS " + BASELINE_MARKER_TABLE);
+    }
+
+    private String columnType(String columnName) {
+        return jdbcTemplate.queryForObject(
+                "SELECT column_type FROM information_schema.columns "
+                        + "WHERE table_schema = DATABASE() AND table_name = 'auth_sessions' AND column_name = ?",
+                String.class,
+                columnName
+        );
+    }
+
+    private boolean columnIsNullable(String columnName) {
+        String nullable = jdbcTemplate.queryForObject(
+                "SELECT is_nullable FROM information_schema.columns "
+                        + "WHERE table_schema = DATABASE() AND table_name = 'auth_sessions' AND column_name = ?",
+                String.class,
+                columnName
+        );
+        return "YES".equals(nullable);
+    }
+
+    private boolean indexExists(String indexName) {
+        Integer indexCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM information_schema.statistics "
+                        + "WHERE table_schema = DATABASE() AND table_name = 'auth_sessions' AND index_name = ?",
+                Integer.class,
+                indexName
+        );
+        return indexCount != null && indexCount > 0;
+    }
+
+    private String deleteRule(String constraintName) {
+        return jdbcTemplate.queryForObject(
+                "SELECT delete_rule FROM information_schema.referential_constraints "
+                        + "WHERE constraint_schema = DATABASE() AND constraint_name = ?",
+                String.class,
+                constraintName
+        );
+    }
+}

--- a/src/test/java/uk/gegc/quizmaker/features/auth/infra/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/uk/gegc/quizmaker/features/auth/infra/security/JwtAuthenticationFilterTest.java
@@ -20,6 +20,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import uk.gegc.quizmaker.features.auth.application.AuthSessionService;
+import uk.gegc.quizmaker.shared.util.TrustedProxyUtil;
 
 import java.io.IOException;
 import java.util.List;
@@ -40,7 +42,10 @@ public class JwtAuthenticationFilterTest {
     FilterChain filterChain;
 
     @Mock
-    JwtTokenService jwtTokenService;
+    AuthSessionService authSessionService;
+
+    @Mock
+    TrustedProxyUtil trustedProxyUtil;
 
     JwtAuthenticationFilter authenticationFilter;
     private ListAppender<ILoggingEvent> logWatcher;
@@ -49,7 +54,7 @@ public class JwtAuthenticationFilterTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        authenticationFilter = new JwtAuthenticationFilter(jwtTokenService);
+        authenticationFilter = new JwtAuthenticationFilter(authSessionService, trustedProxyUtil);
         SecurityContextHolder.clearContext();
         
         // Set up log capture
@@ -84,13 +89,11 @@ public class JwtAuthenticationFilterTest {
         Authentication authentication = mock(Authentication.class);
 
         when(httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer " + token);
-        when(jwtTokenService.validateToken(token)).thenReturn(true);
-        when(jwtTokenService.getAuthentication(token)).thenReturn(authentication);
+        when(authSessionService.authenticateAccessToken(token)).thenReturn(authentication);
 
         authenticationFilter.doFilterInternal(httpServletRequest, httpServletResponse, filterChain);
 
-        verify(jwtTokenService).validateToken(token);
-        verify(jwtTokenService).getAuthentication(token);
+        verify(authSessionService).authenticateAccessToken(token);
         verify(filterChain).doFilter(httpServletRequest, httpServletResponse);
 
         assertThat(SecurityContextHolder.getContext().getAuthentication())
@@ -103,12 +106,11 @@ public class JwtAuthenticationFilterTest {
         String token = "invalid-token";
 
         when(httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer " + token);
-        when(jwtTokenService.validateToken(token)).thenReturn(false);
+        when(authSessionService.authenticateAccessToken(token)).thenReturn(null);
 
         authenticationFilter.doFilterInternal(httpServletRequest, httpServletResponse, filterChain);
 
-        verify(jwtTokenService).validateToken(token);
-        verify(jwtTokenService, never()).getAuthentication(anyString());
+        verify(authSessionService).authenticateAccessToken(token);
         verify(filterChain).doFilter(httpServletRequest, httpServletResponse);
 
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
@@ -121,7 +123,7 @@ public class JwtAuthenticationFilterTest {
 
         authenticationFilter.doFilterInternal(httpServletRequest, httpServletResponse, filterChain);
 
-        verify(jwtTokenService, never()).validateToken(anyString());
+        verify(authSessionService, never()).authenticateAccessToken(anyString());
         verify(filterChain).doFilter(httpServletRequest, httpServletResponse);
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
     }
@@ -134,8 +136,7 @@ public class JwtAuthenticationFilterTest {
         when(authentication.getName()).thenReturn("testuser");
 
         when(httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer " + token);
-        when(jwtTokenService.validateToken(token)).thenReturn(true);
-        when(jwtTokenService.getAuthentication(token)).thenReturn(authentication);
+        when(authSessionService.authenticateAccessToken(token)).thenReturn(authentication);
 
         authenticationFilter.doFilterInternal(httpServletRequest, httpServletResponse, filterChain);
 
@@ -159,16 +160,16 @@ public class JwtAuthenticationFilterTest {
         String userAgent = "TestClient/1.0";
 
         when(httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer " + token);
-        when(httpServletRequest.getRemoteAddr()).thenReturn(clientIp);
         when(httpServletRequest.getRequestURI()).thenReturn(requestUri);
         when(httpServletRequest.getHeader("User-Agent")).thenReturn(userAgent);
-        when(jwtTokenService.validateToken(token)).thenReturn(false);
+        when(trustedProxyUtil.getClientIp(httpServletRequest)).thenReturn(clientIp);
+        when(authSessionService.authenticateAccessToken(token)).thenReturn(null);
 
         authenticationFilter.doFilterInternal(httpServletRequest, httpServletResponse, filterChain);
 
         assertThat(logWatcher.list)
                 .extracting(ILoggingEvent::getLevel, ILoggingEvent::getMessage)
-                .anyMatch(tuple -> tuple.toList().equals(List.of(Level.WARN, "Invalid JWT token received from IP: {}, URI: {}, User-Agent: {}")));
+                .anyMatch(tuple -> tuple.toList().equals(List.of(Level.WARN, "Invalid access token received from IP: {}, URI: {}, User-Agent: {}")));
                 
         // Verify we logged the security details
         ILoggingEvent warnEvent = logWatcher.list.stream()

--- a/src/test/java/uk/gegc/quizmaker/features/auth/infra/security/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/uk/gegc/quizmaker/features/auth/infra/security/OAuth2AuthenticationSuccessHandlerTest.java
@@ -14,6 +14,8 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.web.RedirectStrategy;
 import org.springframework.test.util.ReflectionTestUtils;
+import uk.gegc.quizmaker.features.auth.api.dto.JwtResponse;
+import uk.gegc.quizmaker.features.auth.application.AuthSessionService;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -33,7 +35,7 @@ import static org.mockito.Mockito.*;
 class OAuth2AuthenticationSuccessHandlerTest {
 
     @Mock
-    private JwtTokenService jwtTokenService;
+    private AuthSessionService authSessionService;
 
     @Mock
     private HttpServletRequest request;
@@ -55,15 +57,15 @@ class OAuth2AuthenticationSuccessHandlerTest {
 
     @BeforeEach
     void setUp() {
-        handler = new OAuth2AuthenticationSuccessHandler(jwtTokenService);
+        handler = new OAuth2AuthenticationSuccessHandler(authSessionService);
         ReflectionTestUtils.setField(handler, "oauth2RedirectUri", testRedirectUri);
         
         // Set mock redirect strategy
         handler.setRedirectStrategy(redirectStrategy);
 
         // Setup default mocks with lenient for optional usage
-        lenient().when(jwtTokenService.generateAccessToken(any(Authentication.class))).thenReturn(testAccessToken);
-        lenient().when(jwtTokenService.generateRefreshToken(any(Authentication.class))).thenReturn(testRefreshToken);
+        lenient().when(authSessionService.issueTokens(any(Authentication.class)))
+                .thenReturn(new JwtResponse(testAccessToken, testRefreshToken, 1L, 1L));
         lenient().when(response.isCommitted()).thenReturn(false);
         lenient().when(authentication.getName()).thenReturn("testuser");
     }
@@ -75,8 +77,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
         handler.onAuthenticationSuccess(request, response, authentication);
 
         // Then
-        verify(jwtTokenService).generateAccessToken(authentication);
-        verify(jwtTokenService).generateRefreshToken(authentication);
+        verify(authSessionService).issueTokens(authentication);
         
         ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
         verify(redirectStrategy).sendRedirect(eq(request), eq(response), urlCaptor.capture());
@@ -98,8 +99,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
 
         // Then
         verify(redirectStrategy, never()).sendRedirect(any(), any(), any());
-        verify(jwtTokenService).generateAccessToken(authentication);
-        verify(jwtTokenService).generateRefreshToken(authentication);
+        verify(authSessionService).issueTokens(authentication);
     }
 
     @Test
@@ -122,8 +122,9 @@ class OAuth2AuthenticationSuccessHandlerTest {
     void determineTargetUrl_EncodesSpecialCharacters() {
         // Given - tokens with special characters that need encoding
         String tokenWithSpecialChars = "token.with-special_chars+and/symbols";
-        when(jwtTokenService.generateAccessToken(any())).thenReturn(tokenWithSpecialChars);
-        when(jwtTokenService.generateRefreshToken(any())).thenReturn(tokenWithSpecialChars);
+        when(authSessionService.issueTokens(any())).thenReturn(
+                new JwtResponse(tokenWithSpecialChars, tokenWithSpecialChars, 1L, 1L)
+        );
 
         // When
         String targetUrl = handler.determineTargetUrl(request, response, authentication);
@@ -156,8 +157,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
         handler.determineTargetUrl(request, response, authentication);
 
         // Then
-        verify(jwtTokenService).generateAccessToken(authentication);
-        verify(jwtTokenService).generateRefreshToken(authentication);
+        verify(authSessionService).issueTokens(authentication);
     }
 
     @Test
@@ -208,8 +208,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
         handler.onAuthenticationSuccess(request, response, oauth2Authentication);
 
         // Then
-        verify(jwtTokenService).generateAccessToken(oauth2Authentication);
-        verify(jwtTokenService).generateRefreshToken(oauth2Authentication);
+        verify(authSessionService).issueTokens(oauth2Authentication);
         verify(redirectStrategy).sendRedirect(any(), any(), any());
     }
 
@@ -279,10 +278,9 @@ class OAuth2AuthenticationSuccessHandlerTest {
         handler.onAuthenticationSuccess(request, response, authentication);
 
         // Then - verify execution order
-        var inOrder = inOrder(jwtTokenService, response, redirectStrategy);
+        var inOrder = inOrder(authSessionService, response, redirectStrategy);
         
-        inOrder.verify(jwtTokenService).generateAccessToken(authentication);
-        inOrder.verify(jwtTokenService).generateRefreshToken(authentication);
+        inOrder.verify(authSessionService).issueTokens(authentication);
         inOrder.verify(response).isCommitted();
         inOrder.verify(redirectStrategy).sendRedirect(eq(request), eq(response), anyString());
     }
@@ -327,8 +325,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
         handler.onAuthenticationSuccess(request, response, customAuth);
 
         // Then
-        verify(jwtTokenService).generateAccessToken(customAuth);
-        verify(jwtTokenService).generateRefreshToken(customAuth);
+        verify(authSessionService).issueTokens(customAuth);
         
         ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
         verify(redirectStrategy).sendRedirect(any(), any(), urlCaptor.capture());
@@ -338,4 +335,3 @@ class OAuth2AuthenticationSuccessHandlerTest {
         assertThat(redirectUrl).contains("refreshToken=");
     }
 }
-

--- a/src/test/java/uk/gegc/quizmaker/security/JwtTokenServiceTest.java
+++ b/src/test/java/uk/gegc/quizmaker/security/JwtTokenServiceTest.java
@@ -25,10 +25,12 @@ import uk.gegc.quizmaker.features.user.domain.repository.UserRepository;
 
 import javax.crypto.SecretKey;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,6 +51,7 @@ public class JwtTokenServiceTest {
     private ListAppender<ILoggingEvent> logWatcher;
     private Logger jwtProviderLogger;
     private final Map<String, LocalDateTime> passwordVersionStore = new ConcurrentHashMap<>();
+    private final Map<String, UUID> userIds = new ConcurrentHashMap<>();
 
     @BeforeEach
     void setUp() {
@@ -56,6 +59,7 @@ public class JwtTokenServiceTest {
         base64Secret = Base64.getEncoder().encodeToString(secretKey.getEncoded());
 
         passwordVersionStore.clear();
+        userIds.clear();
         userRepository = mock(UserRepository.class);
         when(userRepository.findByUsername(anyString()))
                 .thenAnswer(invocation -> {
@@ -66,6 +70,7 @@ public class JwtTokenServiceTest {
                     );
                     uk.gegc.quizmaker.features.user.domain.model.User user = new uk.gegc.quizmaker.features.user.domain.model.User();
                     user.setUsername(username);
+                    user.setId(userIds.computeIfAbsent(username, key -> UUID.nameUUIDFromBytes(key.getBytes())));
                     user.setPasswordChangedAt(passwordChangedAt);
                     return java.util.Optional.of(user);
                 });
@@ -102,7 +107,8 @@ public class JwtTokenServiceTest {
                 "Alice", null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
         );
 
-        String token = jwtTokenService.generateAccessToken(authentication);
+        UUID sessionId = UUID.randomUUID();
+        String token = jwtTokenService.generateAccessToken(authentication, sessionId);
         assertThat(token).isNotBlank();
 
         Claims claims = Jwts.parser()
@@ -113,6 +119,8 @@ public class JwtTokenServiceTest {
 
         assertThat(claims.getSubject()).isEqualTo("Alice");
         assertThat(claims.get("type", String.class)).isEqualTo("access");
+        assertThat(claims.get("sid", String.class)).isEqualTo(sessionId.toString());
+        assertThat(claims.get("uid", String.class)).isEqualTo(userIds.get("Alice").toString());
 
         Date issuedAt = claims.getIssuedAt();
         Date expirationDate = claims.getExpiration();
@@ -126,9 +134,10 @@ public class JwtTokenServiceTest {
     void generateAccessToken_edge_twoCalls_differentIssuedAtAndExpiry() throws InterruptedException {
         Authentication authentication = new UsernamePasswordAuthenticationToken("Bob", null, List.of());
 
-        String token1 = jwtTokenService.generateAccessToken(authentication);
+        UUID sessionId = UUID.randomUUID();
+        String token1 = jwtTokenService.generateAccessToken(authentication, sessionId);
         Thread.sleep(1000);
-        String token2 = jwtTokenService.generateAccessToken(authentication);
+        String token2 = jwtTokenService.generateAccessToken(authentication, sessionId);
 
         assertThat(token1).isNotEqualTo(token2);
 
@@ -144,7 +153,12 @@ public class JwtTokenServiceTest {
     void generateRefreshToken_happyPath_containsRefreshTypeAndSubjectAndExpiry() {
         Authentication authentication = new UsernamePasswordAuthenticationToken("Carol", null, List.of());
 
-        String token = jwtTokenService.generateRefreshToken(authentication);
+        UUID sessionId = UUID.randomUUID();
+        String token = jwtTokenService.generateRefreshToken(
+                authentication,
+                sessionId,
+                new Date(System.currentTimeMillis() + refreshTokenValidityInMs)
+        );
         assertThat(token).isNotBlank();
 
         Claims claims = Jwts.parser()
@@ -155,6 +169,7 @@ public class JwtTokenServiceTest {
 
         assertThat(claims.getSubject()).isEqualTo("Carol");
         assertThat(claims.get("type")).isEqualTo("refresh");
+        assertThat(claims.get("sid", String.class)).isEqualTo(sessionId.toString());
 
         Date issuedAt = claims.getIssuedAt();
         Date expiration = claims.getExpiration();
@@ -166,17 +181,54 @@ public class JwtTokenServiceTest {
     @DisplayName("validateToken: valid access token returns true")
     void validateToken_happyPath_validTokenReturnsTrue() {
         Authentication authentication = new UsernamePasswordAuthenticationToken("John", null, List.of());
-        String validToken = jwtTokenService.generateAccessToken(authentication);
+        String validToken = jwtTokenService.generateAccessToken(authentication, UUID.randomUUID());
 
         boolean result = jwtTokenService.validateToken(validToken);
         assertThat(result).isTrue();
     }
 
     @Test
+    @DisplayName("purpose validation accepts only the token type requested by the caller")
+    void validateTokenForPurpose_rejectsOppositeTokenType() {
+        Authentication authentication = new UsernamePasswordAuthenticationToken("Purpose", null, List.of());
+        UUID sessionId = UUID.randomUUID();
+        String accessToken = jwtTokenService.generateAccessToken(authentication, sessionId);
+        String refreshToken = jwtTokenService.generateRefreshToken(
+                authentication,
+                sessionId,
+                new Date(System.currentTimeMillis() + refreshTokenValidityInMs)
+        );
+
+        assertThat(jwtTokenService.validateAccessToken(accessToken)).isPresent();
+        assertThat(jwtTokenService.validateRefreshToken(accessToken)).isEmpty();
+        assertThat(jwtTokenService.validateRefreshToken(refreshToken)).isPresent();
+        assertThat(jwtTokenService.validateAccessToken(refreshToken)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("access validation rejects a correctly signed legacy token without a session identity")
+    void validateAccessToken_legacyTokenWithoutSessionIdentity_returnsEmpty() {
+        Date issuedAt = new Date();
+        String legacyAccessToken = Jwts.builder()
+                .subject("Legacy")
+                .issuedAt(issuedAt)
+                .expiration(new Date(issuedAt.getTime() + accessTokenValidityInMs))
+                .claim("type", "access")
+                .claim("pwdChangedAt", passwordVersionStore
+                        .computeIfAbsent("Legacy", ignored -> LocalDateTime.now().minusMinutes(5))
+                        .toInstant(ZoneOffset.UTC)
+                        .toEpochMilli())
+                .signWith(secretKey)
+                .compact();
+
+        assertThat(jwtTokenService.validateAccessToken(legacyAccessToken)).isEmpty();
+    }
+
+    @Test
     @DisplayName("validateToken: rejects token if passwordChangedAt is newer than claim")
     void validateToken_passwordChangedAfterIssuance_returnsFalse() {
         Authentication authentication = new UsernamePasswordAuthenticationToken("Versioned", null, List.of());
-        String token = jwtTokenService.generateAccessToken(authentication);
+        String token = jwtTokenService.generateAccessToken(authentication, UUID.randomUUID());
 
         passwordVersionStore.put("Versioned", LocalDateTime.now().plusMinutes(1));
 
@@ -226,7 +278,11 @@ public class JwtTokenServiceTest {
     void getUsername_happyPath_returnsCorrectUsername() {
         Authentication authentication = new UsernamePasswordAuthenticationToken("Lenny", null, List.of());
 
-        String token = jwtTokenService.generateRefreshToken(authentication);
+        String token = jwtTokenService.generateRefreshToken(
+                authentication,
+                UUID.randomUUID(),
+                new Date(System.currentTimeMillis() + refreshTokenValidityInMs)
+        );
         String username = jwtTokenService.getUsername(token);
         assertThat(username).isEqualTo("Lenny");
     }
@@ -250,7 +306,7 @@ public class JwtTokenServiceTest {
         provider.init();
 
         Authentication initial = new UsernamePasswordAuthenticationToken("Bill", null, List.of());
-        String token = provider.generateAccessToken(initial);
+        String token = provider.generateAccessToken(initial, UUID.randomUUID());
 
         Authentication result = provider.getAuthentication(token);
 

--- a/src/test/java/uk/gegc/quizmaker/service/auth/AuthServiceImplTest.java
+++ b/src/test/java/uk/gegc/quizmaker/service/auth/AuthServiceImplTest.java
@@ -1,6 +1,5 @@
 package uk.gegc.quizmaker.service.auth;
 
-import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,9 +22,9 @@ import uk.gegc.quizmaker.features.auth.api.dto.LoginRequest;
 import uk.gegc.quizmaker.features.auth.api.dto.RefreshRequest;
 import uk.gegc.quizmaker.features.auth.api.dto.RegisterRequest;
 import uk.gegc.quizmaker.features.auth.application.impl.AuthServiceImpl;
+import uk.gegc.quizmaker.features.auth.application.AuthSessionService;
 import uk.gegc.quizmaker.features.auth.domain.model.PasswordResetToken;
 import uk.gegc.quizmaker.features.auth.domain.repository.PasswordResetTokenRepository;
-import uk.gegc.quizmaker.features.auth.infra.security.JwtTokenService;
 import uk.gegc.quizmaker.features.user.api.dto.AuthenticatedUserDto;
 import uk.gegc.quizmaker.features.user.domain.model.Role;
 import uk.gegc.quizmaker.features.user.domain.model.RoleName;
@@ -67,7 +66,7 @@ class AuthServiceImplTest {
     @Mock
     private AuthenticationManager authManager;
     @Mock
-    private JwtTokenService jwtTokenService;
+    private AuthSessionService authSessionService;
 
     @Mock
     private PasswordResetTokenRepository passwordResetTokenRepository;
@@ -207,21 +206,13 @@ class AuthServiceImplTest {
         Authentication auth = mock(Authentication.class);
         when(authManager.authenticate(any()))
                 .thenReturn(auth);
-        when(jwtTokenService.generateAccessToken(auth))
-                .thenReturn("access.jwt");
-        when(jwtTokenService.generateRefreshToken(auth))
-                .thenReturn("refresh.jwt");
-        when(jwtTokenService.getAccessTokenValidityInMs())
-                .thenReturn(1000L);
-        when(jwtTokenService.getRefreshTokenValidityInMs())
-                .thenReturn(5000L);
+        JwtResponse expected = new JwtResponse("access.jwt", "refresh.jwt", 1000L, 5000L);
+        when(authSessionService.issueTokens(auth)).thenReturn(expected);
 
         JwtResponse resp = authService.login(req);
 
-        assertEquals("access.jwt", resp.accessToken());
-        assertEquals("refresh.jwt", resp.refreshToken());
-        assertEquals(1000L, resp.accessExpiresInMs());
-        assertEquals(5000L, resp.refreshExpiresInMs());
+        assertEquals(expected, resp);
+        verify(authSessionService).issueTokens(auth);
     }
 
     @Test
@@ -239,54 +230,35 @@ class AuthServiceImplTest {
     }
 
     @Test
-    @DisplayName("refresh: valid refresh token returns new access token")
+    @DisplayName("refresh: delegates session-bound token rotation")
     void refresh_happy() {
         var req = new RefreshRequest("valid.token");
-        when(jwtTokenService.validateToken("valid.token")).thenReturn(true);
-        Claims claims = mock(Claims.class);
-        when(claims.get("type", String.class)).thenReturn("refresh");
-        when(jwtTokenService.getClaims("valid.token")).thenReturn(claims);
-
-        Authentication auth = mock(Authentication.class);
-        when(jwtTokenService.getAuthentication("valid.token")).thenReturn(auth);
-        when(jwtTokenService.generateAccessToken(auth)).thenReturn("new.access");
-        when(jwtTokenService.getAccessTokenValidityInMs()).thenReturn(1234L);
-        when(jwtTokenService.getRefreshTokenValidityInMs()).thenReturn(5678L);
+        JwtResponse expected = new JwtResponse("new.access", "new.refresh", 1234L, 5678L);
+        when(authSessionService.refresh("valid.token")).thenReturn(expected);
 
         JwtResponse out = authService.refresh(req);
 
-        assertEquals("new.access", out.accessToken());
-        assertEquals("valid.token", out.refreshToken());
-        assertEquals(1234L, out.accessExpiresInMs());
-        assertEquals(5678L, out.refreshExpiresInMs());
+        assertEquals(expected, out);
+        verify(authSessionService).refresh("valid.token");
     }
 
     @Test
-    @DisplayName("refresh: invalid token yields 401")
+    @DisplayName("refresh: invalid token failure is preserved")
     void refresh_invalidToken() {
-        when(jwtTokenService.validateToken("bad")).thenReturn(false);
-        var ex = assertThrows(ResponseStatusException.class,
-                () -> authService.refresh(new RefreshRequest("bad")));
-        assertEquals(HttpStatus.UNAUTHORIZED, ex.getStatusCode());
+        UnauthorizedException expected = new UnauthorizedException("Invalid refresh token");
+        when(authSessionService.refresh("bad")).thenThrow(expected);
+
+        assertSame(expected, assertThrows(
+                UnauthorizedException.class,
+                () -> authService.refresh(new RefreshRequest("bad"))
+        ));
     }
 
     @Test
-    @DisplayName("refresh: wrong token type yields 400")
-    void refresh_wrongType() {
-        when(jwtTokenService.validateToken("t")).thenReturn(true);
-        Claims claims = mock(Claims.class);
-        when(claims.get("type", String.class)).thenReturn("access");
-        when(jwtTokenService.getClaims("t")).thenReturn(claims);
-
-        var ex = assertThrows(ResponseStatusException.class,
-                () -> authService.refresh(new RefreshRequest("t")));
-        assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
-    }
-
-    @Test
-    @DisplayName("logout: always succeeds (no-op)")
-    void logout_noException() {
+    @DisplayName("logout: delegates current-session revocation")
+    void logout_delegatesCurrentSessionRevocation() {
         assertDoesNotThrow(() -> authService.logout("any.token"));
+        verify(authSessionService).logout("any.token");
     }
 
     @Test

--- a/src/test/java/uk/gegc/quizmaker/shared/config/PublicApiRoutesTest.java
+++ b/src/test/java/uk/gegc/quizmaker/shared/config/PublicApiRoutesTest.java
@@ -28,6 +28,7 @@ class PublicApiRoutesTest {
                 Arguments.of(HttpMethod.POST, "/api/v1/auth/register"),
                 Arguments.of(HttpMethod.POST, "/api/v1/auth/login"),
                 Arguments.of(HttpMethod.POST, "/api/v1/auth/refresh"),
+                Arguments.of(HttpMethod.POST, "/api/v1/auth/logout"),
                 Arguments.of(HttpMethod.POST, "/api/v1/auth/forgot-password"),
                 Arguments.of(HttpMethod.POST, "/api/v1/auth/reset-password"),
                 Arguments.of(HttpMethod.GET, "/oauth2/authorization/google"),


### PR DESCRIPTION
…on and refresh token rotation

- Introduced AuthSessionService to manage JWT issuance, refresh, and logout.
- Added AuthSession entity to store session data with revocation capabilities.
- Implemented session cleanup scheduler to purge expired sessions.
- Updated AuthServiceImplTest to reflect changes in token handling and session management.
- Created manual testing documentation for token purpose enforcement and logout functionality.
- Added database migration script for auth_sessions table creation.
- Enhanced OpenAPI documentation for refresh and logout endpoints.
- Developed comprehensive tests for AuthSessionService and migration validation.